### PR TITLE
First click wasn't taken into account.

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -10,6 +10,12 @@ var index = new AlgoliaSearch("9JQV0RIHU0", "2219d421236cba4cf37a98e7f97b3ec5").
 	$filters = $("#filter a");
 
 function search(v) {
+	if ($('#search').data('q') == v) {
+		// do not perform the same query twice, results will not change
+		return;
+	}
+	$('#search').data('q', v);
+
 	index.search(v, function(success, content) {
 		if (!success) {
 			return;


### PR DESCRIPTION
Since onChange is triggered when the field lose the focus, another query was performed replacing the current results with new ones; avoiding the icon element to receive the click event.

-> Store the query in the DOM avoiding results to be replaced if the query didn't changed (Fix#3)
