### PR TITLE
fix: copied div margin-top

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -135,7 +135,7 @@ body {
 }
 
 .copied div {
-  margin-top: 400px;
+  margin-top: 450px;
   padding: 30px 0;
   background-color: #7F8C9A;
   background-color: rgba(255, 255, 255, 0.4);


### PR DESCRIPTION
I just noticed that the icons and the white band were overlapping at times when the icon was big. I have bummed up the margin-top a bit to fix this issue.
