### PR TITLE
feature: copy as "SVG Markup" syntax (embeddable in HTML)

### DIFF
--- a/data/batch.json
+++ b/data/batch.json
@@ -1,6 +1,7 @@
 [
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "500px",
     "tags": "brand, logo, social",
     "class": "fa fa-500px",
@@ -9,6 +10,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "adjust",
     "tags": "contrast",
     "class": "fa fa-adjust",
@@ -17,6 +19,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "adn",
     "tags": "brand, logo, social",
     "class": "fa fa-adn",
@@ -25,6 +28,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "align-center",
     "tags": "text editor",
     "class": "fa fa-align-center",
@@ -33,6 +37,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "align-justify",
     "tags": "text editor",
     "class": "fa fa-align-justify",
@@ -41,6 +46,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "align-left",
     "tags": "text editor",
     "class": "fa fa-align-left",
@@ -49,6 +55,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "align-right",
     "tags": "text editor",
     "class": "fa fa-align-right",
@@ -57,6 +64,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "amazon",
     "tags": "brand, logo",
     "class": "fa fa-amazon",
@@ -65,6 +73,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "ambulance",
     "tags": "medical, vehicle",
     "class": "fa fa-ambulance",
@@ -73,6 +82,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "anchor",
     "tags": "",
     "class": "fa fa-anchor",
@@ -81,6 +91,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "android",
     "tags": "brand, logo, robot",
     "class": "fa fa-android",
@@ -89,6 +100,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "angellist",
     "tags": "peace, hand",
     "class": "fa fa-angellist",
@@ -97,6 +109,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "angle-double-down",
     "tags": "chevron, directional",
     "class": "fa fa-angle-double-down",
@@ -105,6 +118,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "angle-double-left",
     "tags": "chevron, directional",
     "class": "fa fa-angle-double-left",
@@ -113,6 +127,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "angle-double-right",
     "tags": "chevron, directional",
     "class": "fa fa-angle-double-right",
@@ -121,6 +136,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "angle-double-up",
     "tags": "chevron, directional",
     "class": "fa fa-angle-double-up",
@@ -129,6 +145,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "angle-down",
     "tags": "chevron, directional",
     "class": "fa fa-angle-down",
@@ -137,6 +154,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "angle-left",
     "tags": "chevron, directional",
     "class": "fa fa-angle-left",
@@ -145,6 +163,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "angle-right",
     "tags": "chevron, directional",
     "class": "fa fa-angle-right",
@@ -153,6 +172,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "angle-up",
     "tags": "chevron, directional",
     "class": "fa fa-angle-up",
@@ -161,6 +181,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "apple",
     "tags": "brand, logo, food, fruit",
     "class": "fa fa-apple",
@@ -169,6 +190,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "archive",
     "tags": "email",
     "class": "fa fa-archive",
@@ -177,6 +199,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "area-chart",
     "tags": "graph",
     "class": "fa fa-area-chart",
@@ -185,6 +208,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "arrow-circle-down",
     "tags": "directional",
     "class": "fa fa-arrow-circle-down",
@@ -193,6 +217,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "arrow-circle-left",
     "tags": "directional",
     "class": "fa fa-arrow-circle-left",
@@ -201,6 +226,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "arrow-circle-o-down",
     "tags": "directional",
     "class": "fa fa-arrow-circle-o-down",
@@ -209,6 +235,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "arrow-circle-o-left",
     "tags": "directional",
     "class": "fa fa-arrow-circle-o-left",
@@ -217,6 +244,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "arrow-circle-o-right",
     "tags": "directional",
     "class": "fa fa-arrow-circle-o-right",
@@ -225,6 +253,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "arrow-circle-o-up",
     "tags": "directional",
     "class": "fa fa-arrow-circle-o-up",
@@ -233,6 +262,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "arrow-circle-right",
     "tags": "directional",
     "class": "fa fa-arrow-circle-right",
@@ -241,6 +271,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "arrow-circle-up",
     "tags": "directional",
     "class": "fa fa-arrow-circle-up",
@@ -249,6 +280,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "arrow-down",
     "tags": "directional",
     "class": "fa fa-arrow-down",
@@ -257,6 +289,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "arrow-left",
     "tags": "directional",
     "class": "fa fa-arrow-left",
@@ -265,6 +298,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "arrow-right",
     "tags": "directional",
     "class": "fa fa-arrow-right",
@@ -273,6 +307,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "arrow-up",
     "tags": "directional",
     "class": "fa fa-arrow-up",
@@ -281,6 +316,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "arrows",
     "tags": "move",
     "class": "fa fa-arrows",
@@ -289,6 +325,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "arrows-alt",
     "tags": "fullscreen, resize, video player",
     "class": "fa fa-arrows-alt",
@@ -297,6 +334,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "arrows-h",
     "tags": "fullscreen, resize, video player, horizontal",
     "class": "fa fa-arrows-h",
@@ -305,6 +343,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "arrows-v",
     "tags": "fullscreen, resize, video player, vertical",
     "class": "fa fa-arrows-v",
@@ -313,6 +352,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "asterisk",
     "tags": "",
     "class": "fa fa-asterisk",
@@ -321,6 +361,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "at",
     "tags": "email",
     "class": "fa fa-at",
@@ -329,6 +370,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "backward",
     "tags": "video player",
     "class": "fa fa-backward",
@@ -337,6 +379,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "balance-scale",
     "tags": "law",
     "class": "fa fa-balance-scale",
@@ -345,6 +388,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "ban",
     "tags": "prohibited",
     "class": "fa fa-ban",
@@ -353,6 +397,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "bar-chart",
     "tags": "",
     "class": "fa fa-bar-chart",
@@ -361,6 +406,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "barcode",
     "tags": "",
     "class": "fa fa-barcode",
@@ -369,6 +415,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "bars",
     "tags": "hamburger menu, more",
     "class": "fa fa-bars",
@@ -377,6 +424,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "battery-empty",
     "tags": "power",
     "class": "fa fa-battery-empty",
@@ -385,6 +433,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "battery-full",
     "tags": "power",
     "class": "fa fa-battery-full",
@@ -393,6 +442,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "battery-half",
     "tags": "power",
     "class": "fa fa-battery-half",
@@ -401,6 +451,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "battery-quarter",
     "tags": "power",
     "class": "fa fa-battery-quarter",
@@ -409,6 +460,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "battery-three-quarters",
     "tags": "power",
     "class": "fa fa-battery-three-quarters",
@@ -417,6 +469,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "bed",
     "tags": "hotel",
     "class": "fa fa-bed",
@@ -425,6 +478,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "beer",
     "tags": "drink, mug, stein, alcohol",
     "class": "fa fa-beer",
@@ -433,6 +487,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "behance",
     "tags": "brand, logo, social",
     "class": "fa fa-behance",
@@ -441,6 +496,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "behance-square",
     "tags": "brand, logo, social",
     "class": "fa fa-behance-square",
@@ -449,6 +505,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "bell",
     "tags": "audio, sound",
     "class": "fa fa-bell",
@@ -457,6 +514,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "bell-o",
     "tags": "audio, sound",
     "class": "fa fa-bell-o",
@@ -465,6 +523,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "bell-slash",
     "tags": "audio, sound, mute",
     "class": "fa fa-bell-slash",
@@ -473,6 +532,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "bell-slash-o",
     "tags": "audio, sound, mute",
     "class": "fa fa-bell-slash-o",
@@ -481,6 +541,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "bicycle",
     "tags": "",
     "class": "fa fa-bicycle",
@@ -489,6 +550,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "binoculars",
     "tags": "",
     "class": "fa fa-binoculars",
@@ -497,6 +559,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "birthday-cake",
     "tags": "party",
     "class": "fa fa-birthday-cake",
@@ -505,6 +568,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "bitbucket",
     "tags": "brand, logo, code, social",
     "class": "fa fa-bitbucket",
@@ -513,6 +577,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "bitbucket-square",
     "tags": "brand, logo, code, social",
     "class": "fa fa-bitbucket-square",
@@ -521,6 +586,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "black-tie",
     "tags": "brand, logo",
     "class": "fa fa-black-tie",
@@ -529,6 +595,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "bluetooth",
     "tags": "logo",
     "class": "fa fa-bluetooth",
@@ -537,6 +604,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "bluetooth-b",
     "tags": "logo",
     "class": "fa fa-bluetooth-b",
@@ -545,6 +613,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "bold",
     "tags": "text editor",
     "class": "fa fa-bold",
@@ -553,6 +622,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "bolt",
     "tags": "flash, lightning bolt",
     "class": "fa fa-bolt",
@@ -561,6 +631,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "bomb",
     "tags": "",
     "class": "fa fa-bomb",
@@ -569,6 +640,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "book",
     "tags": "",
     "class": "fa fa-book",
@@ -577,6 +649,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "bookmark",
     "tags": "",
     "class": "fa fa-bookmark",
@@ -585,6 +658,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "bookmark-o",
     "tags": "",
     "class": "fa fa-bookmark-o",
@@ -593,6 +667,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "briefcase",
     "tags": "suitcase",
     "class": "fa fa-briefcase",
@@ -601,6 +676,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "btc",
     "tags": "bitcoin, logo, brand, currency, money",
     "class": "fa fa-btc",
@@ -609,6 +685,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "bug",
     "tags": "insect",
     "class": "fa fa-bug",
@@ -617,6 +694,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "building",
     "tags": "",
     "class": "fa fa-building",
@@ -625,6 +703,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "building-o",
     "tags": "",
     "class": "fa fa-building-o",
@@ -633,6 +712,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "bullhorn",
     "tags": "speakerphone",
     "class": "fa fa-bullhorn",
@@ -641,6 +721,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "bullseye",
     "tags": "aim, target",
     "class": "fa fa-bullseye",
@@ -649,6 +730,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "bus",
     "tags": "transportation",
     "class": "fa fa-bus",
@@ -657,6 +739,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "buysellads",
     "tags": "brand, logo",
     "class": "fa fa-buysellads",
@@ -665,6 +748,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "calculator",
     "tags": "math",
     "class": "fa fa-calculator",
@@ -673,6 +757,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "calendar",
     "tags": "date",
     "class": "fa fa-calendar",
@@ -681,6 +766,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "calendar-check-o",
     "tags": "date",
     "class": "fa fa-calendar-check-o",
@@ -689,6 +775,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "calendar-minus-o",
     "tags": "date",
     "class": "fa fa-calendar-minus-o",
@@ -697,6 +784,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "calendar-o",
     "tags": "date",
     "class": "fa fa-calendar-o",
@@ -705,6 +793,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "calendar-plus-o",
     "tags": "date",
     "class": "fa fa-calendar-plus-o",
@@ -713,6 +802,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "calendar-times-o",
     "tags": "date",
     "class": "fa fa-calendar-times-o",
@@ -721,6 +811,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "camera",
     "tags": "photographs",
     "class": "fa fa-camera",
@@ -729,6 +820,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "camera-retro",
     "tags": "photographs",
     "class": "fa fa-camera-retro",
@@ -737,6 +829,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "car",
     "tags": "automobile, transporation",
     "class": "fa fa-car",
@@ -745,6 +838,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "caret-down",
     "tags": "directional, triangle",
     "class": "fa fa-caret-down",
@@ -753,6 +847,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "caret-left",
     "tags": "directional, triangle",
     "class": "fa fa-caret-left",
@@ -761,6 +856,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "caret-right",
     "tags": "directional, triangle",
     "class": "fa fa-caret-right",
@@ -769,6 +865,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "caret-square-o-down",
     "tags": "toggle-down, directional",
     "class": "fa fa-caret-square-o-down",
@@ -777,6 +874,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "caret-square-o-left",
     "tags": "toggle-left, directional",
     "class": "fa fa-caret-square-o-left",
@@ -785,6 +883,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "caret-square-o-right",
     "tags": "toggle-right, directional",
     "class": "fa fa-caret-square-o-right",
@@ -793,6 +892,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "caret-square-o-up",
     "tags": "toggle-up, directional",
     "class": "fa fa-caret-square-o-up",
@@ -801,6 +901,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "caret-up",
     "tags": "directional, triangle",
     "class": "fa fa-caret-up",
@@ -809,6 +910,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "cart-arrow-down",
     "tags": "shopping",
     "class": "fa fa-cart-arrow-down",
@@ -817,6 +919,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "cart-plus",
     "tags": "shopping",
     "class": "fa fa-cart-plus",
@@ -825,6 +928,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "cc",
     "tags": "closed captioning",
     "class": "fa fa-cc",
@@ -833,6 +937,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "cc-amex",
     "tags": "credit card, american express, payment",
     "class": "fa fa-cc-amex",
@@ -841,6 +946,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "cc-diners-club",
     "tags": "credit card, payment",
     "class": "fa fa-cc-diners-club",
@@ -849,6 +955,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "cc-discover",
     "tags": "credit card, payment",
     "class": "fa fa-cc-discover",
@@ -857,6 +964,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "cc-jcb",
     "tags": "credit card, payment",
     "class": "fa fa-cc-jcb",
@@ -865,6 +973,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "cc-mastercard",
     "tags": "credit card, payment",
     "class": "fa fa-cc-mastercard",
@@ -873,6 +982,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "cc-paypal",
     "tags": "payment",
     "class": "fa fa-cc-paypal",
@@ -881,6 +991,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "cc-stripe",
     "tags": "payment",
     "class": "fa fa-cc-stripe",
@@ -889,6 +1000,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "cc-visa",
     "tags": "credit card, payment",
     "class": "fa fa-cc-visa",
@@ -897,6 +1009,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "certificate",
     "tags": "seal, prize, award",
     "class": "fa fa-certificate",
@@ -905,6 +1018,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "chain-broken",
     "tags": "unlink, text editor",
     "class": "fa fa-chain-broken",
@@ -913,6 +1027,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "check",
     "tags": "",
     "class": "fa fa-check",
@@ -921,6 +1036,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "check-circle",
     "tags": "",
     "class": "fa fa-check-circle",
@@ -929,6 +1045,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "check-circle-o",
     "tags": "",
     "class": "fa fa-check-circle-o",
@@ -937,6 +1054,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "check-square",
     "tags": "form control",
     "class": "fa fa-check-square",
@@ -945,6 +1063,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "check-square-o",
     "tags": "form control",
     "class": "fa fa-check-square-o",
@@ -953,6 +1072,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "chevron-circle-down",
     "tags": "directional",
     "class": "fa fa-chevron-circle-down",
@@ -961,6 +1081,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "chevron-circle-left",
     "tags": "directional",
     "class": "fa fa-chevron-circle-left",
@@ -969,6 +1090,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "chevron-circle-right",
     "tags": "directional",
     "class": "fa fa-chevron-circle-right",
@@ -977,6 +1099,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "chevron-circle-up",
     "tags": "directional",
     "class": "fa fa-chevron-circle-up",
@@ -985,6 +1108,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "chevron-down",
     "tags": "directional",
     "class": "fa fa-chevron-down",
@@ -993,6 +1117,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "chevron-left",
     "tags": "directional",
     "class": "fa fa-chevron-left",
@@ -1001,6 +1126,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "chevron-right",
     "tags": "directional",
     "class": "fa fa-chevron-right",
@@ -1009,6 +1135,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "chevron-up",
     "tags": "directional",
     "class": "fa fa-chevron-up",
@@ -1017,6 +1144,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "child",
     "tags": "",
     "class": "fa fa-child",
@@ -1025,6 +1153,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "chrome",
     "tags": "brand, browser, logo",
     "class": "fa fa-chrome",
@@ -1033,6 +1162,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "circle",
     "tags": "form control",
     "class": "fa fa-circle",
@@ -1041,6 +1171,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "circle-o",
     "tags": "form control",
     "class": "fa fa-circle-o",
@@ -1049,6 +1180,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "circle-o-notch",
     "tags": "",
     "class": "fa fa-circle-o-notch",
@@ -1057,6 +1189,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "circle-thin",
     "tags": "",
     "class": "fa fa-circle-thin",
@@ -1065,6 +1198,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "clipboard",
     "tags": "paste",
     "class": "fa fa-clipboard",
@@ -1073,6 +1207,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "clock-o",
     "tags": "timer",
     "class": "fa fa-clock-o",
@@ -1081,6 +1216,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "clone",
     "tags": "copy, duplicate",
     "class": "fa fa-clone",
@@ -1089,6 +1225,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "cloud",
     "tags": "",
     "class": "fa fa-cloud",
@@ -1097,6 +1234,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "cloud-download",
     "tags": "",
     "class": "fa fa-cloud-download",
@@ -1105,6 +1243,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "cloud-upload",
     "tags": "",
     "class": "fa fa-cloud-upload",
@@ -1113,6 +1252,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "code",
     "tags": "source",
     "class": "fa fa-code",
@@ -1121,6 +1261,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "code-fork",
     "tags": "git",
     "class": "fa fa-code-fork",
@@ -1129,6 +1270,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "codepen",
     "tags": "brand, logo",
     "class": "fa fa-codepen",
@@ -1137,6 +1279,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "codiepie",
     "tags": "brand, logo",
     "class": "fa fa-codiepie",
@@ -1145,6 +1288,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "coffee",
     "tags": "cup, drink, mug",
     "class": "fa fa-coffee",
@@ -1153,6 +1297,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "cog",
     "tags": "gear, settings",
     "class": "fa fa-cog",
@@ -1161,6 +1306,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "cogs",
     "tags": "gears, settings",
     "class": "fa fa-cogs",
@@ -1169,6 +1315,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "columns",
     "tags": "text editor",
     "class": "fa fa-columns",
@@ -1177,6 +1324,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "comment",
     "tags": "chat, speech bubble",
     "class": "fa fa-comment",
@@ -1185,6 +1333,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "comment-o",
     "tags": "chat, speech bubble",
     "class": "fa fa-comment-o",
@@ -1193,6 +1342,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "commenting",
     "tags": "chat, speech bubble",
     "class": "fa fa-commenting",
@@ -1201,6 +1351,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "commenting-o",
     "tags": "chat, speech bubble",
     "class": "fa fa-commenting-o",
@@ -1209,6 +1360,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "comments",
     "tags": "chat, speech bubble",
     "class": "fa fa-comments",
@@ -1217,6 +1369,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "comments-o",
     "tags": "chat, speech bubble",
     "class": "fa fa-comments-o",
@@ -1225,6 +1378,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "compass",
     "tags": "directions, map, navigation",
     "class": "fa fa-compass",
@@ -1233,6 +1387,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "compress",
     "tags": "arrows, resize, contract, shrink",
     "class": "fa fa-compress",
@@ -1241,6 +1396,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "connectdevelop",
     "tags": "brand, logo",
     "class": "fa fa-connectdevelop",
@@ -1249,6 +1405,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "contao",
     "tags": "brand, logo",
     "class": "fa fa-contao",
@@ -1257,6 +1414,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "copyright",
     "tags": "",
     "class": "fa fa-copyright",
@@ -1265,6 +1423,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "creative-commons",
     "tags": "logo",
     "class": "fa fa-creative-commons",
@@ -1273,6 +1432,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "credit-card",
     "tags": "money, payment",
     "class": "fa fa-credit-card",
@@ -1281,6 +1441,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "credit-card-alt",
     "tags": "money, payment",
     "class": "fa fa-credit-card-alt",
@@ -1289,6 +1450,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "crop",
     "tags": "",
     "class": "fa fa-crop",
@@ -1297,6 +1459,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "crosshairs",
     "tags": "",
     "class": "fa fa-crosshairs",
@@ -1305,6 +1468,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "css3",
     "tags": "brand, logo",
     "class": "fa fa-css3",
@@ -1313,6 +1477,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "cube",
     "tags": "",
     "class": "fa fa-cube",
@@ -1321,6 +1486,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "cubes",
     "tags": "",
     "class": "fa fa-cubes",
@@ -1329,6 +1495,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "cutlery",
     "tags": "food, fork, knife",
     "class": "fa fa-cutlery",
@@ -1337,6 +1504,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "dashcube",
     "tags": "brand, logo",
     "class": "fa fa-dashcube",
@@ -1345,6 +1513,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "database",
     "tags": "",
     "class": "fa fa-database",
@@ -1353,6 +1522,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "delicious",
     "tags": "brand, logo, social",
     "class": "fa fa-delicious",
@@ -1361,6 +1531,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "desktop",
     "tags": "computer, pc, monitor",
     "class": "fa fa-desktop",
@@ -1369,6 +1540,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "deviantart",
     "tags": "brand, logo",
     "class": "fa fa-deviantart",
@@ -1377,6 +1549,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "diamond",
     "tags": "gem",
     "class": "fa fa-diamond",
@@ -1385,6 +1558,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "digg",
     "tags": "brand, logo, social",
     "class": "fa fa-digg",
@@ -1393,6 +1567,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "dot-circle-o",
     "tags": "form control, target",
     "class": "fa fa-dot-circle-o",
@@ -1401,6 +1576,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "download",
     "tags": "",
     "class": "fa fa-download",
@@ -1409,6 +1585,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "dribbble",
     "tags": "brand, logo, social, basketball",
     "class": "fa fa-dribbble",
@@ -1417,6 +1594,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "dropbox",
     "tags": "brand, logo",
     "class": "fa fa-dropbox",
@@ -1425,6 +1603,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "drupal",
     "tags": "brand, logo",
     "class": "fa fa-drupal",
@@ -1433,6 +1612,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "edge",
     "tags": "brand, browser, logo",
     "class": "fa fa-edge",
@@ -1441,6 +1621,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "eject",
     "tags": "video player",
     "class": "fa fa-eject",
@@ -1449,6 +1630,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "ellipsis-h",
     "tags": "horizontal",
     "class": "fa fa-ellipsis-h",
@@ -1457,6 +1639,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "ellipsis-v",
     "tags": "vertical",
     "class": "fa fa-ellipsis-v",
@@ -1465,6 +1648,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "empire",
     "tags": "",
     "class": "fa fa-empire",
@@ -1473,6 +1657,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "envelope",
     "tags": "email",
     "class": "fa fa-envelope",
@@ -1481,6 +1666,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "envelope-o",
     "tags": "email",
     "class": "fa fa-envelope-o",
@@ -1489,6 +1675,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "envelope-square",
     "tags": "email",
     "class": "fa fa-envelope-square",
@@ -1497,6 +1684,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "eraser",
     "tags": "undo, delete",
     "class": "fa fa-eraser",
@@ -1505,6 +1693,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "eur",
     "tags": "euro, currency, money",
     "class": "fa fa-eur",
@@ -1513,6 +1702,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "exchange",
     "tags": "transfer, arrows",
     "class": "fa fa-exchange",
@@ -1521,6 +1711,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "exclamation",
     "tags": "alert, caution, warning",
     "class": "fa fa-exclamation",
@@ -1529,6 +1720,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "exclamation-circle",
     "tags": "alert, caution, warning, sign",
     "class": "fa fa-exclamation-circle",
@@ -1537,6 +1729,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "exclamation-triangle",
     "tags": "alert, caution, warning, sign",
     "class": "fa fa-exclamation-triangle",
@@ -1545,6 +1738,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "expand",
     "tags": "arrows, resize",
     "class": "fa fa-expand",
@@ -1553,6 +1747,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "expeditedssl",
     "tags": "brand, logo",
     "class": "fa fa-expeditedssl",
@@ -1561,6 +1756,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "external-link",
     "tags": "",
     "class": "fa fa-external-link",
@@ -1569,6 +1765,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "external-link-square",
     "tags": "",
     "class": "fa fa-external-link-square",
@@ -1577,6 +1774,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "eye",
     "tags": "show",
     "class": "fa fa-eye",
@@ -1585,6 +1783,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "eye-slash",
     "tags": "hide",
     "class": "fa fa-eye-slash",
@@ -1593,6 +1792,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "eyedropper",
     "tags": "",
     "class": "fa fa-eyedropper",
@@ -1601,6 +1801,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "facebook",
     "tags": "brand, logo, social",
     "class": "fa fa-facebook",
@@ -1609,6 +1810,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "facebook-official",
     "tags": "brand, logo, social",
     "class": "fa fa-facebook-official",
@@ -1617,6 +1819,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "facebook-square",
     "tags": "brand, logo, social",
     "class": "fa fa-facebook-square",
@@ -1625,6 +1828,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "fast-backward",
     "tags": "video player",
     "class": "fa fa-fast-backward",
@@ -1633,6 +1837,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "fast-forward",
     "tags": "video player",
     "class": "fa fa-fast-forward",
@@ -1641,6 +1846,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "fax",
     "tags": "",
     "class": "fa fa-fax",
@@ -1649,6 +1855,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "female",
     "tags": "gender, sex, person, user",
     "class": "fa fa-female",
@@ -1657,6 +1864,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "fighter-jet",
     "tags": "airplane",
     "class": "fa fa-fighter-jet",
@@ -1665,6 +1873,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "file",
     "tags": "document",
     "class": "fa fa-file",
@@ -1673,6 +1882,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "file-archive-o",
     "tags": "zip",
     "class": "fa fa-file-archive-o",
@@ -1681,6 +1891,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "file-audio-o",
     "tags": "sound",
     "class": "fa fa-file-audio-o",
@@ -1689,6 +1900,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "file-code-o",
     "tags": "",
     "class": "fa fa-file-code-o",
@@ -1697,6 +1909,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "file-excel-o",
     "tags": "",
     "class": "fa fa-file-excel-o",
@@ -1705,6 +1918,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "file-image-o",
     "tags": "photo, picture",
     "class": "fa fa-file-image-o",
@@ -1713,6 +1927,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "file-o",
     "tags": "text editor, document",
     "class": "fa fa-file-o",
@@ -1721,6 +1936,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "file-pdf-o",
     "tags": "",
     "class": "fa fa-file-pdf-o",
@@ -1729,6 +1945,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "file-powerpoint-o",
     "tags": "",
     "class": "fa fa-file-powerpoint-o",
@@ -1737,6 +1954,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "file-text",
     "tags": "text editor, document",
     "class": "fa fa-file-text",
@@ -1745,6 +1963,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "file-text-o",
     "tags": "text editor, document",
     "class": "fa fa-file-text-o",
@@ -1753,6 +1972,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "file-video-o",
     "tags": "",
     "class": "fa fa-file-video-o",
@@ -1761,6 +1981,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "file-word-o",
     "tags": "",
     "class": "fa fa-file-word-o",
@@ -1769,6 +1990,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "files-o",
     "tags": "clone, copy, documents, duplicate",
     "class": "fa fa-files-o",
@@ -1777,6 +1999,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "film",
     "tags": "",
     "class": "fa fa-film",
@@ -1785,6 +2008,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "filter",
     "tags": "",
     "class": "fa fa-filter",
@@ -1793,6 +2017,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "fire",
     "tags": "flame, hot",
     "class": "fa fa-fire",
@@ -1801,6 +2026,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "fire-extinguisher",
     "tags": "",
     "class": "fa fa-fire-extinguisher",
@@ -1809,6 +2035,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "firefox",
     "tags": "brand, browser, logo",
     "class": "fa fa-firefox",
@@ -1817,6 +2044,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "flag",
     "tags": "",
     "class": "fa fa-flag",
@@ -1825,6 +2053,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "flag-checkered",
     "tags": "",
     "class": "fa fa-flag-checkered",
@@ -1833,6 +2062,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "flag-o",
     "tags": "",
     "class": "fa fa-flag-o",
@@ -1841,6 +2071,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "flask",
     "tags": "beaker, science",
     "class": "fa fa-flask",
@@ -1849,6 +2080,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "flickr",
     "tags": "brand, logo",
     "class": "fa fa-flickr",
@@ -1857,6 +2089,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "floppy-o",
     "tags": "save",
     "class": "fa fa-floppy-o",
@@ -1865,6 +2098,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "folder",
     "tags": "",
     "class": "fa fa-folder",
@@ -1873,6 +2107,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "folder-o",
     "tags": "",
     "class": "fa fa-folder-o",
@@ -1881,6 +2116,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "folder-open",
     "tags": "",
     "class": "fa fa-folder-open",
@@ -1889,6 +2125,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "folder-open-o",
     "tags": "",
     "class": "fa fa-folder-open-o",
@@ -1897,6 +2134,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "font",
     "tags": "",
     "class": "fa fa-font",
@@ -1905,6 +2143,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "fonticons",
     "tags": "brand, logo",
     "class": "fa fa-fonticons",
@@ -1913,6 +2152,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "fort-awesome",
     "tags": "brand, castle, logo",
     "class": "fa fa-fort-awesome",
@@ -1921,6 +2161,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "forumbee",
     "tags": "brand, logo",
     "class": "fa fa-forumbee",
@@ -1929,6 +2170,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "forward",
     "tags": "video player",
     "class": "fa fa-forward",
@@ -1937,6 +2179,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "foursquare",
     "tags": "brand, logo, social",
     "class": "fa fa-foursquare",
@@ -1945,6 +2188,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "frown-o",
     "tags": "face, smiley, ratings, rate, unlike",
     "class": "fa fa-frown-o",
@@ -1953,6 +2197,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "futbol-o",
     "tags": "soccer, ball, sports",
     "class": "fa fa-futbol-o",
@@ -1961,6 +2206,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "gamepad",
     "tags": "controller",
     "class": "fa fa-gamepad",
@@ -1969,6 +2215,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "gavel",
     "tags": "law, legal, judge",
     "class": "fa fa-gavel",
@@ -1977,6 +2224,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "gbp",
     "tags": "currency, money",
     "class": "fa fa-gbp",
@@ -1985,6 +2233,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "genderless",
     "tags": "circle",
     "class": "fa fa-genderless",
@@ -1993,6 +2242,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "get-pocket",
     "tags": "brand, logo",
     "class": "fa fa-get-pocket",
@@ -2001,6 +2251,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "gg",
     "tags": "brand, logo",
     "class": "fa fa-gg",
@@ -2009,6 +2260,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "gg-circle",
     "tags": "brand, logo",
     "class": "fa fa-gg-circle",
@@ -2017,6 +2269,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "gift",
     "tags": "present",
     "class": "fa fa-gift",
@@ -2025,6 +2278,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "git",
     "tags": "brand, logo",
     "class": "fa fa-git",
@@ -2033,6 +2287,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "git-square",
     "tags": "brand, logo",
     "class": "fa fa-git-square",
@@ -2041,6 +2296,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "github",
     "tags": "brand, logo",
     "class": "fa fa-github",
@@ -2049,6 +2305,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "github-alt",
     "tags": "brand, logo",
     "class": "fa fa-github-alt",
@@ -2057,6 +2314,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "github-square",
     "tags": "brand, logo",
     "class": "fa fa-github-square",
@@ -2065,6 +2323,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "glass",
     "tags": "drink, martini, alcohol",
     "class": "fa fa-glass",
@@ -2073,6 +2332,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "globe",
     "tags": "earth, planet, world",
     "class": "fa fa-globe",
@@ -2081,6 +2341,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "google",
     "tags": "brand, logo, social",
     "class": "fa fa-google",
@@ -2089,6 +2350,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "google-plus",
     "tags": "brand, logo, social",
     "class": "fa fa-google-plus",
@@ -2097,6 +2359,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "google-plus-square",
     "tags": "brand, logo, social",
     "class": "fa fa-google-plus-square",
@@ -2105,6 +2368,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "google-wallet",
     "tags": "brand, logo, payment",
     "class": "fa fa-google-wallet",
@@ -2113,6 +2377,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "graduation-cap",
     "tags": "education, mortar board",
     "class": "fa fa-graduation-cap",
@@ -2121,6 +2386,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "gratipay",
     "tags": "brand, gittip, logo, heart",
     "class": "fa fa-gratipay",
@@ -2129,6 +2395,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "h-square",
     "tags": "medical",
     "class": "fa fa-h-square",
@@ -2137,6 +2404,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "hacker-news",
     "tags": "brand, logo, ycombinator",
     "class": "fa fa-hacker-news",
@@ -2145,6 +2413,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "hand-lizard-o",
     "tags": "",
     "class": "fa fa-hand-lizard-o",
@@ -2153,6 +2422,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "hand-o-down",
     "tags": "directional, finger, pointer",
     "class": "fa fa-hand-o-down",
@@ -2161,6 +2431,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "hand-o-left",
     "tags": "directional, finger, pointer",
     "class": "fa fa-hand-o-left",
@@ -2169,6 +2440,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "hand-o-right",
     "tags": "directional, finger, pointer",
     "class": "fa fa-hand-o-right",
@@ -2177,6 +2449,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "hand-o-up",
     "tags": "directional, finger, pointer",
     "class": "fa fa-hand-o-up",
@@ -2185,6 +2458,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "hand-paper-o",
     "tags": "stop",
     "class": "fa fa-hand-paper-o",
@@ -2193,6 +2467,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "hand-peace-o",
     "tags": "",
     "class": "fa fa-hand-peace-o",
@@ -2201,6 +2476,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "hand-pointer-o",
     "tags": "pointer",
     "class": "fa fa-hand-pointer-o",
@@ -2209,6 +2485,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "hand-rock-o",
     "tags": "fist, grab",
     "class": "fa fa-hand-rock-o",
@@ -2217,6 +2494,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "hand-scissors-o",
     "tags": "",
     "class": "fa fa-hand-scissors-o",
@@ -2225,6 +2503,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "hand-spock-o",
     "tags": "",
     "class": "fa fa-hand-spock-o",
@@ -2233,6 +2512,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "hashtag",
     "tags": "pound",
     "class": "fa fa-hashtag",
@@ -2241,6 +2521,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "hdd-o",
     "tags": "hard drive, computer, disk",
     "class": "fa fa-hdd-o",
@@ -2249,6 +2530,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "header",
     "tags": "",
     "class": "fa fa-header",
@@ -2257,6 +2539,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "headphones",
     "tags": "music, audio, sound",
     "class": "fa fa-headphones",
@@ -2265,6 +2548,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "heart",
     "tags": "like, favorite",
     "class": "fa fa-heart",
@@ -2273,6 +2557,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "heart-o",
     "tags": "unlike, unfavorite",
     "class": "fa fa-heart-o",
@@ -2281,6 +2566,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "heartbeat",
     "tags": "health",
     "class": "fa fa-heartbeat",
@@ -2289,6 +2575,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "history",
     "tags": "",
     "class": "fa fa-history",
@@ -2297,6 +2584,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "home",
     "tags": "",
     "class": "fa fa-home",
@@ -2305,6 +2593,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "hospital-o",
     "tags": "medical, building",
     "class": "fa fa-hospital-o",
@@ -2313,6 +2602,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "hourglass",
     "tags": "busy, loading, timer",
     "class": "fa fa-hourglass",
@@ -2321,6 +2611,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "hourglass-end",
     "tags": "busy, loading, timer",
     "class": "fa fa-hourglass-end",
@@ -2329,6 +2620,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "hourglass-half",
     "tags": "busy, loading, timer",
     "class": "fa fa-hourglass-half",
@@ -2337,6 +2629,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "hourglass-o",
     "tags": "busy, loading, timer",
     "class": "fa fa-hourglass-o",
@@ -2345,6 +2638,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "hourglass-start",
     "tags": "busy, loading, timer",
     "class": "fa fa-hourglass-start",
@@ -2353,6 +2647,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "houzz",
     "tags": "brand, logo",
     "class": "fa fa-houzz",
@@ -2361,6 +2656,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "html5",
     "tags": "brand, logo, web",
     "class": "fa fa-html5",
@@ -2369,6 +2665,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "i-cursor",
     "tags": "",
     "class": "fa fa-i-cursor",
@@ -2377,6 +2674,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "ils",
     "tags": "shekel, israeli, money, currency",
     "class": "fa fa-ils",
@@ -2385,6 +2683,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "inbox",
     "tags": "email",
     "class": "fa fa-inbox",
@@ -2393,6 +2692,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "indent",
     "tags": "",
     "class": "fa fa-indent",
@@ -2401,6 +2701,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "industry",
     "tags": "factory",
     "class": "fa fa-industry",
@@ -2409,6 +2710,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "info",
     "tags": "",
     "class": "fa fa-info",
@@ -2417,6 +2719,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "info-circle",
     "tags": "",
     "class": "fa fa-info-circle",
@@ -2425,6 +2728,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "inr",
     "tags": "rupee, currency, money",
     "class": "fa fa-inr",
@@ -2433,6 +2737,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "instagram",
     "tags": "brand, logo",
     "class": "fa fa-instagram",
@@ -2441,6 +2746,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "internet-explorer",
     "tags": "brand, browser, logo",
     "class": "fa fa-internet-explorer",
@@ -2449,6 +2755,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "ioxhost",
     "tags": "brand, logo",
     "class": "fa fa-ioxhost",
@@ -2457,6 +2764,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "italic",
     "tags": "",
     "class": "fa fa-italic",
@@ -2465,6 +2773,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "joomla",
     "tags": "brand, logo",
     "class": "fa fa-joomla",
@@ -2473,6 +2782,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "jpy",
     "tags": "cny, rmb, yen, currency, money",
     "class": "fa fa-jpy",
@@ -2481,6 +2791,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "jsfiddle",
     "tags": "brand, logo",
     "class": "fa fa-jsfiddle",
@@ -2489,6 +2800,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "key",
     "tags": "lock, security",
     "class": "fa fa-key",
@@ -2497,6 +2809,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "keyboard-o",
     "tags": "computer",
     "class": "fa fa-keyboard-o",
@@ -2505,6 +2818,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "krw",
     "tags": "won, currency, money",
     "class": "fa fa-krw",
@@ -2513,6 +2827,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "language",
     "tags": "translation",
     "class": "fa fa-language",
@@ -2521,6 +2836,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "laptop",
     "tags": "computer",
     "class": "fa fa-laptop",
@@ -2529,6 +2845,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "lastfm",
     "tags": "brand, logo",
     "class": "fa fa-lastfm",
@@ -2537,6 +2854,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "lastfm-square",
     "tags": "brand, logo",
     "class": "fa fa-lastfm-square",
@@ -2545,6 +2863,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "leaf",
     "tags": "plant",
     "class": "fa fa-leaf",
@@ -2553,6 +2872,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "leanpub",
     "tags": "brand, logo, book",
     "class": "fa fa-leanpub",
@@ -2561,6 +2881,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "lemon-o",
     "tags": "food, fruit",
     "class": "fa fa-lemon-o",
@@ -2569,6 +2890,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "level-down",
     "tags": "",
     "class": "fa fa-level-down",
@@ -2577,6 +2899,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "level-up",
     "tags": "",
     "class": "fa fa-level-up",
@@ -2585,6 +2908,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "life-ring",
     "tags": "bouy, life-saver, support",
     "class": "fa fa-life-ring",
@@ -2593,6 +2917,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "lightbulb-o",
     "tags": "",
     "class": "fa fa-lightbulb-o",
@@ -2601,6 +2926,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "line-chart",
     "tags": "graph",
     "class": "fa fa-line-chart",
@@ -2609,6 +2935,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "link",
     "tags": "chain",
     "class": "fa fa-link",
@@ -2617,6 +2944,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "linkedin",
     "tags": "brand, logo",
     "class": "fa fa-linkedin",
@@ -2625,6 +2953,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "linkedin-square",
     "tags": "brand, logo",
     "class": "fa fa-linkedin-square",
@@ -2633,6 +2962,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "linux",
     "tags": "brand, logo, penguin, bird, animal",
     "class": "fa fa-linux",
@@ -2641,6 +2971,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "list",
     "tags": "text editor",
     "class": "fa fa-list",
@@ -2649,6 +2980,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "list-alt",
     "tags": "text editor",
     "class": "fa fa-list-alt",
@@ -2657,6 +2989,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "list-ol",
     "tags": "text editor",
     "class": "fa fa-list-ol",
@@ -2665,6 +2998,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "list-ul",
     "tags": "text editor",
     "class": "fa fa-list-ul",
@@ -2673,6 +3007,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "location-arrow",
     "tags": "",
     "class": "fa fa-location-arrow",
@@ -2681,6 +3016,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "lock",
     "tags": "security",
     "class": "fa fa-lock",
@@ -2689,6 +3025,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "long-arrow-down",
     "tags": "directional",
     "class": "fa fa-long-arrow-down",
@@ -2697,6 +3034,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "long-arrow-left",
     "tags": "directional",
     "class": "fa fa-long-arrow-left",
@@ -2705,6 +3043,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "long-arrow-right",
     "tags": "directional",
     "class": "fa fa-long-arrow-right",
@@ -2713,6 +3052,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "long-arrow-up",
     "tags": "directional",
     "class": "fa fa-long-arrow-up",
@@ -2721,6 +3061,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "magic",
     "tags": "wand",
     "class": "fa fa-magic",
@@ -2729,6 +3070,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "magnet",
     "tags": "",
     "class": "fa fa-magnet",
@@ -2737,6 +3079,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "male",
     "tags": "gender, sex, person, user",
     "class": "fa fa-male",
@@ -2745,6 +3088,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "map",
     "tags": "",
     "class": "fa fa-map",
@@ -2753,6 +3097,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "map-marker",
     "tags": "location",
     "class": "fa fa-map-marker",
@@ -2761,6 +3106,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "map-o",
     "tags": "",
     "class": "fa fa-map-o",
@@ -2769,6 +3115,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "map-pin",
     "tags": "location",
     "class": "fa fa-map-pin",
@@ -2777,6 +3124,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "map-signs",
     "tags": "streets",
     "class": "fa fa-map-signs",
@@ -2785,6 +3133,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "mars",
     "tags": "male, gender",
     "class": "fa fa-mars",
@@ -2793,6 +3142,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "mars-double",
     "tags": "gay, homosexual, sexual orientation",
     "class": "fa fa-mars-double",
@@ -2801,6 +3151,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "mars-stroke",
     "tags": "male, gender",
     "class": "fa fa-mars-stroke",
@@ -2809,6 +3160,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "mars-stroke-h",
     "tags": "male, gender",
     "class": "fa fa-mars-stroke-h",
@@ -2817,6 +3169,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "maxcdn",
     "tags": "brand, logo",
     "class": "fa fa-maxcdn",
@@ -2825,6 +3178,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "meanpath",
     "tags": "brand, logo",
     "class": "fa fa-meanpath",
@@ -2833,6 +3187,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "medium",
     "tags": "brand, logo",
     "class": "fa fa-medium",
@@ -2841,6 +3196,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "medkit",
     "tags": "medical, health, hospital",
     "class": "fa fa-medkit",
@@ -2849,6 +3205,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "meh-o",
     "tags": "face, smiley, ratings, rate",
     "class": "fa fa-meh-o",
@@ -2857,6 +3214,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "mercury",
     "tags": "",
     "class": "fa fa-mercury",
@@ -2865,6 +3223,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "microphone",
     "tags": "audio, sound, voice",
     "class": "fa fa-microphone",
@@ -2873,6 +3232,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "microphone-slash",
     "tags": "audio, mute, sound, voice",
     "class": "fa fa-microphone-slash",
@@ -2881,6 +3241,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "minus",
     "tags": "remove",
     "class": "fa fa-minus",
@@ -2889,6 +3250,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "minus-circle",
     "tags": "remove",
     "class": "fa fa-minus-circle",
@@ -2897,6 +3259,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "minus-square",
     "tags": "remove, form control, collapse",
     "class": "fa fa-minus-square",
@@ -2905,6 +3268,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "minus-square-o",
     "tags": "form control, resize, collapse",
     "class": "fa fa-minus-square-o",
@@ -2913,6 +3277,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "mixcloud",
     "tags": "brand, logo",
     "class": "fa fa-mixcloud",
@@ -2921,6 +3286,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "mobile",
     "tags": "phone",
     "class": "fa fa-mobile",
@@ -2929,6 +3295,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "modx",
     "tags": "brand, logo",
     "class": "fa fa-modx",
@@ -2937,6 +3304,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "money",
     "tags": "currency, dollar bill, payment",
     "class": "fa fa-money",
@@ -2945,6 +3313,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "moon-o",
     "tags": "crescent, night",
     "class": "fa fa-moon-o",
@@ -2953,6 +3322,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "motorcycle",
     "tags": "vehicle",
     "class": "fa fa-motorcycle",
@@ -2961,6 +3331,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "mouse-pointer",
     "tags": "arrow, cursor",
     "class": "fa fa-mouse-pointer",
@@ -2969,6 +3340,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "music",
     "tags": "",
     "class": "fa fa-music",
@@ -2977,6 +3349,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "neuter",
     "tags": "gender",
     "class": "fa fa-neuter",
@@ -2985,6 +3358,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "newspaper-o",
     "tags": "",
     "class": "fa fa-newspaper-o",
@@ -2993,6 +3367,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "object-group",
     "tags": "",
     "class": "fa fa-object-group",
@@ -3001,6 +3376,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "object-ungroup",
     "tags": "",
     "class": "fa fa-object-ungroup",
@@ -3009,6 +3385,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "odnoklassniki",
     "tags": "brand, logo, social",
     "class": "fa fa-odnoklassniki",
@@ -3017,6 +3394,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "odnoklassniki-square",
     "tags": "brand, logo, social",
     "class": "fa fa-odnoklassniki-square",
@@ -3025,6 +3403,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "opencart",
     "tags": "brand, logo",
     "class": "fa fa-opencart",
@@ -3033,6 +3412,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "openid",
     "tags": "brand, logo",
     "class": "fa fa-openid",
@@ -3041,6 +3421,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "opera",
     "tags": "brand, browser, logo",
     "class": "fa fa-opera",
@@ -3049,6 +3430,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "optin-monster",
     "tags": "brand, logo",
     "class": "fa fa-optin-monster",
@@ -3057,6 +3439,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "outdent",
     "tags": "text editor",
     "class": "fa fa-outdent",
@@ -3065,6 +3448,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "pagelines",
     "tags": "brand, logo, leaf, plant",
     "class": "fa fa-pagelines",
@@ -3073,6 +3457,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "paint-brush",
     "tags": "art",
     "class": "fa fa-paint-brush",
@@ -3081,6 +3466,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "paper-plane",
     "tags": "airplane, sent",
     "class": "fa fa-paper-plane",
@@ -3089,6 +3475,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "paper-plane-o",
     "tags": "airplane",
     "class": "fa fa-paper-plane-o",
@@ -3097,6 +3484,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "paperclip",
     "tags": "file attachment",
     "class": "fa fa-paperclip",
@@ -3105,6 +3493,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "paragraph",
     "tags": "text editor",
     "class": "fa fa-paragraph",
@@ -3113,6 +3502,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "pause",
     "tags": "video player",
     "class": "fa fa-pause",
@@ -3121,6 +3511,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "pause-circle",
     "tags": "video player",
     "class": "fa fa-pause-circle",
@@ -3129,6 +3520,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "pause-circle-o",
     "tags": "video player",
     "class": "fa fa-pause-circle-o",
@@ -3137,6 +3529,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "paw",
     "tags": "animal, pet, print",
     "class": "fa fa-paw",
@@ -3145,6 +3538,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "paypal",
     "tags": "payment, brand, logo",
     "class": "fa fa-paypal",
@@ -3153,6 +3547,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "pencil",
     "tags": "write, edit",
     "class": "fa fa-pencil",
@@ -3161,6 +3556,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "pencil-square",
     "tags": "write, edit",
     "class": "fa fa-pencil-square",
@@ -3169,6 +3565,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "pencil-square-o",
     "tags": "write, edit",
     "class": "fa fa-pencil-square-o",
@@ -3177,6 +3574,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "percent",
     "tags": "",
     "class": "fa fa-percent",
@@ -3185,6 +3583,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "phone",
     "tags": "telephone",
     "class": "fa fa-phone",
@@ -3193,6 +3592,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "phone-square",
     "tags": "telephone",
     "class": "fa fa-phone-square",
@@ -3201,6 +3601,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "picture-o",
     "tags": "",
     "class": "fa fa-picture-o",
@@ -3209,6 +3610,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "pie-chart",
     "tags": "graph",
     "class": "fa fa-pie-chart",
@@ -3217,6 +3619,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "pied-piper",
     "tags": "brand, logo",
     "class": "fa fa-pied-piper",
@@ -3225,6 +3628,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "pied-piper-alt",
     "tags": "brand, logo, snackdick",
     "class": "fa fa-pied-piper-alt",
@@ -3233,6 +3637,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "pinterest",
     "tags": "brand, logo, social",
     "class": "fa fa-pinterest",
@@ -3241,6 +3646,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "pinterest-p",
     "tags": "brand, logo, social",
     "class": "fa fa-pinterest-p",
@@ -3249,6 +3655,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "pinterest-square",
     "tags": "brand, logo, social",
     "class": "fa fa-pinterest-square",
@@ -3257,6 +3664,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "plane",
     "tags": "airplane, jet, transporation",
     "class": "fa fa-plane",
@@ -3265,6 +3673,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "play",
     "tags": "video player, triangle",
     "class": "fa fa-play",
@@ -3273,6 +3682,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "play-circle",
     "tags": "video player",
     "class": "fa fa-play-circle",
@@ -3281,6 +3691,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "play-circle-o",
     "tags": "video player",
     "class": "fa fa-play-circle-o",
@@ -3289,6 +3700,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "plug",
     "tags": "power",
     "class": "fa fa-plug",
@@ -3297,6 +3709,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "plus",
     "tags": "add",
     "class": "fa fa-plus",
@@ -3305,6 +3718,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "plus-circle",
     "tags": "add",
     "class": "fa fa-plus-circle",
@@ -3313,6 +3727,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "plus-square",
     "tags": "add, medical",
     "class": "fa fa-plus-square",
@@ -3321,6 +3736,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "plus-square-o",
     "tags": "form controls, add, expand, resize",
     "class": "fa fa-plus-square-o",
@@ -3329,6 +3745,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "power-off",
     "tags": "on",
     "class": "fa fa-power-off",
@@ -3337,6 +3754,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "print",
     "tags": "printer, computer",
     "class": "fa fa-print",
@@ -3345,6 +3763,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "product-hunt",
     "tags": "brand, logo",
     "class": "fa fa-product-hunt",
@@ -3353,6 +3772,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "puzzle-piece",
     "tags": "jigsaw",
     "class": "fa fa-puzzle-piece",
@@ -3361,6 +3781,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "qq",
     "tags": "brand, logo",
     "class": "fa fa-qq",
@@ -3369,6 +3790,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "qrcode",
     "tags": "",
     "class": "fa fa-qrcode",
@@ -3377,6 +3799,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "question",
     "tags": "help",
     "class": "fa fa-question",
@@ -3385,6 +3808,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "question-circle",
     "tags": "help",
     "class": "fa fa-question-circle",
@@ -3393,6 +3817,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "quote-left",
     "tags": "",
     "class": "fa fa-quote-left",
@@ -3401,6 +3826,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "quote-right",
     "tags": "",
     "class": "fa fa-quote-right",
@@ -3409,6 +3835,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "random",
     "tags": "",
     "class": "fa fa-random",
@@ -3417,6 +3844,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "rebel",
     "tags": "brand, logo",
     "class": "fa fa-rebel",
@@ -3425,6 +3853,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "recycle",
     "tags": "",
     "class": "fa fa-recycle",
@@ -3433,6 +3862,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "reddit",
     "tags": "brand, logo, alien, social",
     "class": "fa fa-reddit",
@@ -3441,6 +3871,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "reddit-alien",
     "tags": "brand, logo, alien, social",
     "class": "fa fa-reddit-alien",
@@ -3449,6 +3880,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "reddit-square",
     "tags": "brand, logo, alien, social",
     "class": "fa fa-reddit-square",
@@ -3457,6 +3889,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "refresh",
     "tags": "reload",
     "class": "fa fa-refresh",
@@ -3465,6 +3898,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "registered",
     "tags": "trademark",
     "class": "fa fa-registered",
@@ -3473,6 +3907,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "renren",
     "tags": "brand, logo, social",
     "class": "fa fa-renren",
@@ -3481,6 +3916,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "repeat",
     "tags": "rotate-right, text editor",
     "class": "fa fa-repeat",
@@ -3489,6 +3925,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "reply",
     "tags": "mail-reply, email",
     "class": "fa fa-reply",
@@ -3497,6 +3934,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "reply-all",
     "tags": "email",
     "class": "fa fa-reply-all",
@@ -3505,6 +3943,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "retweet",
     "tags": "twitter",
     "class": "fa fa-retweet",
@@ -3513,6 +3952,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "road",
     "tags": "",
     "class": "fa fa-road",
@@ -3521,6 +3961,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "rocket",
     "tags": "spaceship",
     "class": "fa fa-rocket",
@@ -3529,6 +3970,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "rss",
     "tags": "",
     "class": "fa fa-rss",
@@ -3537,6 +3979,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "rss-square",
     "tags": "",
     "class": "fa fa-rss-square",
@@ -3545,6 +3988,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "rub",
     "tags": "ruble, rouble, currency, money",
     "class": "fa fa-rub",
@@ -3553,6 +3997,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "safari",
     "tags": "brand, browser, logo",
     "class": "fa fa-safari",
@@ -3561,6 +4006,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "scissors",
     "tags": "cut",
     "class": "fa fa-scissors",
@@ -3569,6 +4015,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "scribd",
     "tags": "brand, logo",
     "class": "fa fa-scribd",
@@ -3577,6 +4024,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "search",
     "tags": "find, magnifying glass",
     "class": "fa fa-search",
@@ -3585,6 +4033,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "search-minus",
     "tags": "zoom out, magnifying glass",
     "class": "fa fa-search-minus",
@@ -3593,6 +4042,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "search-plus",
     "tags": "zoom in, magnifying glass",
     "class": "fa fa-search-plus",
@@ -3601,6 +4051,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "sellsy",
     "tags": "brand, logo",
     "class": "fa fa-sellsy",
@@ -3609,6 +4060,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "server",
     "tags": "",
     "class": "fa fa-server",
@@ -3617,6 +4069,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "share",
     "tags": "mail-forward, email",
     "class": "fa fa-share",
@@ -3625,6 +4078,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "share-alt",
     "tags": "social",
     "class": "fa fa-share-alt",
@@ -3633,6 +4087,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "share-alt-square",
     "tags": "social",
     "class": "fa fa-share-alt-square",
@@ -3641,6 +4096,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "share-square",
     "tags": "social",
     "class": "fa fa-share-square",
@@ -3649,6 +4105,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "share-square-o",
     "tags": "social",
     "class": "fa fa-share-square-o",
@@ -3657,6 +4114,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "shield",
     "tags": "",
     "class": "fa fa-shield",
@@ -3665,6 +4123,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "ship",
     "tags": "boat",
     "class": "fa fa-ship",
@@ -3673,6 +4132,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "shirtsinbulk",
     "tags": "brand, logo",
     "class": "fa fa-shirtsinbulk",
@@ -3681,6 +4141,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "shopping-bag",
     "tags": "purse",
     "class": "fa fa-shopping-bag",
@@ -3689,6 +4150,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "shopping-basket",
     "tags": "",
     "class": "fa fa-shopping-basket",
@@ -3697,6 +4159,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "shopping-cart",
     "tags": "",
     "class": "fa fa-shopping-cart",
@@ -3705,6 +4168,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "sign-in",
     "tags": "",
     "class": "fa fa-sign-in",
@@ -3713,6 +4177,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "sign-out",
     "tags": "",
     "class": "fa fa-sign-out",
@@ -3721,6 +4186,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "signal",
     "tags": "bars, graph",
     "class": "fa fa-signal",
@@ -3729,6 +4195,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "simplybuilt",
     "tags": "brand, logo",
     "class": "fa fa-simplybuilt",
@@ -3737,6 +4204,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "sitemap",
     "tags": "",
     "class": "fa fa-sitemap",
@@ -3745,6 +4213,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "skyatlas",
     "tags": "brand, logo",
     "class": "fa fa-skyatlas",
@@ -3753,6 +4222,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "skype",
     "tags": "brand, logo, social",
     "class": "fa fa-skype",
@@ -3761,6 +4231,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "slack",
     "tags": "brand, logo, social, hash, pound",
     "class": "fa fa-slack",
@@ -3769,6 +4240,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "sliders",
     "tags": "settings",
     "class": "fa fa-sliders",
@@ -3777,6 +4249,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "slideshare",
     "tags": "",
     "class": "fa fa-slideshare",
@@ -3785,6 +4258,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "smile-o",
     "tags": "face, smiley, ratings, rate, like",
     "class": "fa fa-smile-o",
@@ -3793,6 +4267,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "sort",
     "tags": "unsorted",
     "class": "fa fa-sort",
@@ -3801,6 +4276,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "sort-alpha-asc",
     "tags": "",
     "class": "fa fa-sort-alpha-asc",
@@ -3809,6 +4285,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "sort-alpha-desc",
     "tags": "",
     "class": "fa fa-sort-alpha-desc",
@@ -3817,6 +4294,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "sort-amount-asc",
     "tags": "",
     "class": "fa fa-sort-amount-asc",
@@ -3825,6 +4303,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "sort-amount-desc",
     "tags": "",
     "class": "fa fa-sort-amount-desc",
@@ -3833,6 +4312,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "sort-asc",
     "tags": "sort-down, triangle",
     "class": "fa fa-sort-asc",
@@ -3841,6 +4321,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "sort-desc",
     "tags": "sort-up, triangle",
     "class": "fa fa-sort-desc",
@@ -3849,6 +4330,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "sort-numeric-asc",
     "tags": "",
     "class": "fa fa-sort-numeric-asc",
@@ -3857,6 +4339,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "sort-numeric-desc",
     "tags": "",
     "class": "fa fa-sort-numeric-desc",
@@ -3865,6 +4348,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "soundcloud",
     "tags": "brand, logo, social, music",
     "class": "fa fa-soundcloud",
@@ -3873,6 +4357,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "space-shuttle",
     "tags": "",
     "class": "fa fa-space-shuttle",
@@ -3881,6 +4366,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "spinner",
     "tags": "loading",
     "class": "fa fa-spinner",
@@ -3889,6 +4375,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "spoon",
     "tags": "",
     "class": "fa fa-spoon",
@@ -3897,6 +4384,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "spotify",
     "tags": "brand, logo, social, music",
     "class": "fa fa-spotify",
@@ -3905,6 +4393,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "square",
     "tags": "form control",
     "class": "fa fa-square",
@@ -3913,6 +4402,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "square-o",
     "tags": "form control",
     "class": "fa fa-square-o",
@@ -3921,6 +4411,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "stack-exchange",
     "tags": "brand, social",
     "class": "fa fa-stack-exchange",
@@ -3929,6 +4420,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "stack-overflow",
     "tags": "brand, social",
     "class": "fa fa-stack-overflow",
@@ -3937,6 +4429,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "star",
     "tags": "favorite, ratings, rate",
     "class": "fa fa-star",
@@ -3945,6 +4438,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "star-half",
     "tags": "ratings, rate",
     "class": "fa fa-star-half",
@@ -3953,6 +4447,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "star-half-o",
     "tags": "star-half-empty, star-half-full, ratings, rate",
     "class": "fa fa-star-half-o",
@@ -3961,6 +4456,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "star-o",
     "tags": "favorite, ratings, rate",
     "class": "fa fa-star-o",
@@ -3969,6 +4465,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "steam",
     "tags": "brand, logo, social, games, valve",
     "class": "fa fa-steam",
@@ -3977,6 +4474,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "steam-square",
     "tags": "brand, logo, social, games, valve",
     "class": "fa fa-steam-square",
@@ -3985,6 +4483,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "step-backward",
     "tags": "video player",
     "class": "fa fa-step-backward",
@@ -3993,6 +4492,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "step-forward",
     "tags": "video player",
     "class": "fa fa-step-forward",
@@ -4001,6 +4501,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "stethoscope",
     "tags": "medical, doctor",
     "class": "fa fa-stethoscope",
@@ -4009,6 +4510,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "sticky-note",
     "tags": "",
     "class": "fa fa-sticky-note",
@@ -4017,6 +4519,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "sticky-note-o",
     "tags": "",
     "class": "fa fa-sticky-note-o",
@@ -4025,6 +4528,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "stop",
     "tags": "video player, square",
     "class": "fa fa-stop",
@@ -4033,6 +4537,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "stop-circle",
     "tags": "video player",
     "class": "fa fa-stop-circle",
@@ -4041,6 +4546,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "stop-circle-o",
     "tags": "video player",
     "class": "fa fa-stop-circle-o",
@@ -4049,6 +4555,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "street-view",
     "tags": "person, map",
     "class": "fa fa-street-view",
@@ -4057,6 +4564,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "strikethrough",
     "tags": "",
     "class": "fa fa-strikethrough",
@@ -4065,6 +4573,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "stumbleupon",
     "tags": "brand, logo, social",
     "class": "fa fa-stumbleupon",
@@ -4073,6 +4582,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "stumbleupon-circle",
     "tags": "brand, logo, social",
     "class": "fa fa-stumbleupon-circle",
@@ -4081,6 +4591,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "subscript",
     "tags": "",
     "class": "fa fa-subscript",
@@ -4089,6 +4600,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "subway",
     "tags": "transportation",
     "class": "fa fa-subway",
@@ -4097,6 +4609,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "suitcase",
     "tags": "briefcase, business",
     "class": "fa fa-suitcase",
@@ -4105,6 +4618,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "sun-o",
     "tags": "weather",
     "class": "fa fa-sun-o",
@@ -4113,6 +4627,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "superscript",
     "tags": "",
     "class": "fa fa-superscript",
@@ -4121,6 +4636,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "table",
     "tags": "text editor",
     "class": "fa fa-table",
@@ -4129,6 +4645,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "tablet",
     "tags": "computer, ipad",
     "class": "fa fa-tablet",
@@ -4137,6 +4654,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "tachometer",
     "tags": "dashboard, speedometer",
     "class": "fa fa-tachometer",
@@ -4145,6 +4663,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "tag",
     "tags": "",
     "class": "fa fa-tag",
@@ -4153,6 +4672,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "tags",
     "tags": "",
     "class": "fa fa-tags",
@@ -4161,6 +4681,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "tasks",
     "tags": "",
     "class": "fa fa-tasks",
@@ -4169,6 +4690,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "taxi",
     "tags": "cab, automobile, car, transportation",
     "class": "fa fa-taxi",
@@ -4177,6 +4699,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "television",
     "tags": "computer, display, monitor, tv",
     "class": "fa fa-television",
@@ -4185,6 +4708,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "tencent-weibo",
     "tags": "brand, logo, social",
     "class": "fa fa-tencent-weibo",
@@ -4193,6 +4717,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "terminal",
     "tags": "console",
     "class": "fa fa-terminal",
@@ -4201,6 +4726,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "text-height",
     "tags": "",
     "class": "fa fa-text-height",
@@ -4209,6 +4735,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "text-width",
     "tags": "",
     "class": "fa fa-text-width",
@@ -4217,6 +4744,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "th",
     "tags": "",
     "class": "fa fa-th",
@@ -4225,6 +4753,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "th-large",
     "tags": "",
     "class": "fa fa-th-large",
@@ -4233,6 +4762,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "th-list",
     "tags": "",
     "class": "fa fa-th-list",
@@ -4241,6 +4771,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "thumb-tack",
     "tags": "pin",
     "class": "fa fa-thumb-tack",
@@ -4249,6 +4780,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "thumbs-down",
     "tags": "dislike, ratings",
     "class": "fa fa-thumbs-down",
@@ -4257,6 +4789,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "thumbs-o-down",
     "tags": "dislike, ratings",
     "class": "fa fa-thumbs-o-down",
@@ -4265,6 +4798,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "thumbs-o-up",
     "tags": "like, ratings",
     "class": "fa fa-thumbs-o-up",
@@ -4273,6 +4807,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "thumbs-up",
     "tags": "like, ratings",
     "class": "fa fa-thumbs-up",
@@ -4281,6 +4816,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "ticket",
     "tags": "film, movie, admission",
     "class": "fa fa-ticket",
@@ -4289,6 +4825,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "times",
     "tags": "close, remove, delete",
     "class": "fa fa-times",
@@ -4297,6 +4834,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "times-circle",
     "tags": "close, remove, delete",
     "class": "fa fa-times-circle",
@@ -4305,6 +4843,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "times-circle-o",
     "tags": "close, remove, delete",
     "class": "fa fa-times-circle-o",
@@ -4313,6 +4852,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "tint",
     "tags": "",
     "class": "fa fa-tint",
@@ -4321,6 +4861,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "toggle-off",
     "tags": "settings, switch",
     "class": "fa fa-toggle-off",
@@ -4329,6 +4870,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "toggle-on",
     "tags": "settings, switch",
     "class": "fa fa-toggle-on",
@@ -4337,6 +4879,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "trademark",
     "tags": "",
     "class": "fa fa-trademark",
@@ -4345,6 +4888,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "train",
     "tags": "transportation",
     "class": "fa fa-train",
@@ -4353,6 +4897,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "transgender",
     "tags": "gender",
     "class": "fa fa-transgender",
@@ -4361,6 +4906,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "transgender-alt",
     "tags": "gender",
     "class": "fa fa-transgender-alt",
@@ -4369,6 +4915,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "trash",
     "tags": "delete",
     "class": "fa fa-trash",
@@ -4377,6 +4924,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "trash-o",
     "tags": "delete",
     "class": "fa fa-trash-o",
@@ -4385,6 +4933,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "tree",
     "tags": "",
     "class": "fa fa-tree",
@@ -4393,6 +4942,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "trello",
     "tags": "brand, logo, social",
     "class": "fa fa-trello",
@@ -4401,6 +4951,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "tripadvisor",
     "tags": "brand, logo",
     "class": "fa fa-tripadvisor",
@@ -4409,6 +4960,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "trophy",
     "tags": "prize, award",
     "class": "fa fa-trophy",
@@ -4417,6 +4969,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "truck",
     "tags": "vehicle, transportation",
     "class": "fa fa-truck",
@@ -4425,6 +4978,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "try",
     "tags": "turkish lira, currency, money",
     "class": "fa fa-try",
@@ -4433,6 +4987,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "tty",
     "tags": "teletype",
     "class": "fa fa-tty",
@@ -4441,6 +4996,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "tumblr",
     "tags": "brand, logo, social",
     "class": "fa fa-tumblr",
@@ -4449,6 +5005,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "tumblr-square",
     "tags": "brand, logo, social",
     "class": "fa fa-tumblr-square",
@@ -4457,6 +5014,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "twitch",
     "tags": "brand, logo, video, social",
     "class": "fa fa-twitch",
@@ -4465,6 +5023,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "twitter",
     "tags": "brand, logo, bird, animal, social",
     "class": "fa fa-twitter",
@@ -4473,6 +5032,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "twitter-square",
     "tags": "brand, logo, bird, animal, social",
     "class": "fa fa-twitter-square",
@@ -4481,6 +5041,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "umbrella",
     "tags": "",
     "class": "fa fa-umbrella",
@@ -4489,6 +5050,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "underline",
     "tags": "text editor",
     "class": "fa fa-underline",
@@ -4497,6 +5059,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "undo",
     "tags": "rotate-left",
     "class": "fa fa-undo",
@@ -4505,6 +5068,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "university",
     "tags": "bank, institution, building",
     "class": "fa fa-university",
@@ -4513,6 +5077,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "unlock",
     "tags": "",
     "class": "fa fa-unlock",
@@ -4521,6 +5086,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "unlock-alt",
     "tags": "",
     "class": "fa fa-unlock-alt",
@@ -4529,6 +5095,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "upload",
     "tags": "",
     "class": "fa fa-upload",
@@ -4537,6 +5104,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "usb",
     "tags": "",
     "class": "fa fa-usb",
@@ -4545,6 +5113,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "usd",
     "tags": "dollar, currency, money",
     "class": "fa fa-usd",
@@ -4553,6 +5122,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "user",
     "tags": "person",
     "class": "fa fa-user",
@@ -4561,6 +5131,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "user-md",
     "tags": "medical, doctor",
     "class": "fa fa-user-md",
@@ -4569,6 +5140,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "user-plus",
     "tags": "",
     "class": "fa fa-user-plus",
@@ -4577,6 +5149,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "user-secret",
     "tags": "anonymous, private, incognito",
     "class": "fa fa-user-secret",
@@ -4585,6 +5158,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "user-times",
     "tags": "",
     "class": "fa fa-user-times",
@@ -4593,6 +5167,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "users",
     "tags": "people",
     "class": "fa fa-users",
@@ -4601,6 +5176,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "venus",
     "tags": "female, gender",
     "class": "fa fa-venus",
@@ -4609,6 +5185,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "venus-double",
     "tags": "gay, lesbian, homosexual, sexual orientation",
     "class": "fa fa-venus-double",
@@ -4617,6 +5194,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "venus-mars",
     "tags": "heterosexual, sexual orientation",
     "class": "fa fa-venus-mars",
@@ -4625,6 +5203,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "viacoin",
     "tags": "brand, currency, logo, money",
     "class": "fa fa-viacoin",
@@ -4633,6 +5212,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "video-camera",
     "tags": "",
     "class": "fa fa-video-camera",
@@ -4641,6 +5221,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "vimeo",
     "tags": "brand, logo, social, video",
     "class": "fa fa-vimeo",
@@ -4649,6 +5230,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "vimeo-square",
     "tags": "brand, logo, social, video",
     "class": "fa fa-vimeo-square",
@@ -4657,6 +5239,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "vine",
     "tags": "brand, logo, social",
     "class": "fa fa-vine",
@@ -4665,6 +5248,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "vk",
     "tags": "brand, logo, social",
     "class": "fa fa-vk",
@@ -4673,6 +5257,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "volume-down",
     "tags": "audio, sound",
     "class": "fa fa-volume-down",
@@ -4681,6 +5266,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "volume-off",
     "tags": "audio, sound",
     "class": "fa fa-volume-off",
@@ -4689,6 +5275,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "volume-up",
     "tags": "audio, sound",
     "class": "fa fa-volume-up",
@@ -4697,6 +5284,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "weibo",
     "tags": "brand, logo, social",
     "class": "fa fa-weibo",
@@ -4705,6 +5293,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "weixin",
     "tags": "brand, logo, social, chat",
     "class": "fa fa-weixin",
@@ -4713,6 +5302,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "whatsapp",
     "tags": "brand, logo, social",
     "class": "fa fa-whatsapp",
@@ -4721,6 +5311,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "wheelchair",
     "tags": "handicapped",
     "class": "fa fa-wheelchair",
@@ -4729,6 +5320,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "wifi",
     "tags": "internet, signal, broadcast",
     "class": "fa fa-wifi",
@@ -4737,6 +5329,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "wikipedia-w",
     "tags": "brand, logo",
     "class": "fa fa-wikipedia-w",
@@ -4745,6 +5338,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "windows",
     "tags": "brand, logo, microsoft",
     "class": "fa fa-windows",
@@ -4753,6 +5347,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "wordpress",
     "tags": "brand, logo, social",
     "class": "fa fa-wordpress",
@@ -4761,6 +5356,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "wrench",
     "tags": "tool, settings",
     "class": "fa fa-wrench",
@@ -4769,6 +5365,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "xing",
     "tags": "brand, logo, social",
     "class": "fa fa-xing",
@@ -4777,6 +5374,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "xing-square",
     "tags": "brand, logo, social",
     "class": "fa fa-xing-square",
@@ -4785,6 +5383,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "y-combinator",
     "tags": "brand, logo, social, yc",
     "class": "fa fa-y-combinator",
@@ -4793,6 +5392,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "yahoo",
     "tags": "brand, logo",
     "class": "fa fa-yahoo",
@@ -4801,6 +5401,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "yelp",
     "tags": "brand, logo, social",
     "class": "fa fa-yelp",
@@ -4809,6 +5410,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "youtube",
     "tags": "brand, logo, video, social",
     "class": "fa fa-youtube",
@@ -4817,6 +5419,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "youtube-play",
     "tags": "brand, logo, video, social",
     "class": "fa fa-youtube-play",
@@ -4825,6 +5428,7 @@
   },
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "youtube-square",
     "tags": "brand, logo, video, social",
     "class": "fa fa-youtube-square",
@@ -4834,6 +5438,7 @@
 
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "address-book",
     "tags": "contacts",
     "class": "fi-address-book",
@@ -4842,6 +5447,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "alert",
     "tags": "caution, danger, exclamation, warning sign",
     "class": "fi-alert",
@@ -4850,6 +5456,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "align-center",
     "tags": "text",
     "class": "fi-align-center",
@@ -4858,6 +5465,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "align-justify",
     "tags": "text",
     "class": "fi-align-justify",
@@ -4866,6 +5474,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "align-left",
     "tags": "text",
     "class": "fi-align-left",
@@ -4874,6 +5483,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "align-right",
     "tags": "text",
     "class": "fi-align-right",
@@ -4882,6 +5492,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "anchor",
     "tags": "",
     "class": "fi-anchor",
@@ -4890,6 +5501,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "annotate",
     "tags": "",
     "class": "fi-annotate",
@@ -4898,6 +5510,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "archive",
     "tags": "",
     "class": "fi-archive",
@@ -4906,6 +5519,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "arrow-down",
     "tags": "",
     "class": "fi-arrow-down",
@@ -4914,6 +5528,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "arrow-left",
     "tags": "",
     "class": "fi-arrow-left",
@@ -4922,6 +5537,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "arrow-right",
     "tags": "",
     "class": "fi-arrow-right",
@@ -4930,6 +5546,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "arrow-up",
     "tags": "",
     "class": "fi-arrow-up",
@@ -4938,6 +5555,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "arrows-compress",
     "tags": "resize, contract, shrink",
     "class": "fi-arrows-compress",
@@ -4946,6 +5564,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "arrows-expand",
     "tags": "resize, fullscreen",
     "class": "fi-arrows-expand",
@@ -4954,6 +5573,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "arrows-in",
     "tags": "resize, compress, contract, shrink",
     "class": "fi-arrows-in",
@@ -4962,6 +5582,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "arrows-out",
     "tags": "resize, expand",
     "class": "fi-arrows-out",
@@ -4970,6 +5591,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "asl",
     "tags": "deaf, sign language",
     "class": "fi-asl",
@@ -4978,6 +5600,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "asterisk",
     "tags": "",
     "class": "fi-asterisk",
@@ -4986,6 +5609,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "at-sign",
     "tags": "email",
     "class": "fi-at-sign",
@@ -4994,6 +5618,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "background-color",
     "tags": "text",
     "class": "fi-background-color",
@@ -5002,6 +5627,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "battery-empty",
     "tags": "power",
     "class": "fi-battery-empty",
@@ -5010,6 +5636,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "battery-full",
     "tags": "power",
     "class": "fi-battery-full",
@@ -5018,6 +5645,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "battery-half",
     "tags": "power",
     "class": "fi-battery-half",
@@ -5026,6 +5654,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "bitcoin",
     "tags": "money, currency",
     "class": "fi-bitcoin",
@@ -5034,6 +5663,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "bitcoin-circle",
     "tags": "money, currency",
     "class": "fi-bitcoin-circle",
@@ -5042,6 +5672,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "blind",
     "tags": "",
     "class": "fi-blind",
@@ -5050,6 +5681,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "bluetooth",
     "tags": "logo",
     "class": "fi-bluetooth",
@@ -5058,6 +5690,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "bold",
     "tags": "text",
     "class": "fi-bold",
@@ -5066,6 +5699,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "book",
     "tags": "",
     "class": "fi-book",
@@ -5074,6 +5708,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "book-bookmark",
     "tags": "",
     "class": "fi-book-bookmark",
@@ -5082,6 +5717,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "bookmark",
     "tags": "",
     "class": "fi-bookmark",
@@ -5090,6 +5726,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "braille",
     "tags": "dots",
     "class": "fi-braille",
@@ -5098,6 +5735,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "burst",
     "tags": "seal",
     "class": "fi-burst",
@@ -5106,6 +5744,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "burst-new",
     "tags": "seal",
     "class": "fi-burst-new",
@@ -5114,6 +5753,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "burst-sale",
     "tags": "seal",
     "class": "fi-burst-sale",
@@ -5122,6 +5762,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "calendar",
     "tags": "date",
     "class": "fi-calendar",
@@ -5130,6 +5771,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "camera",
     "tags": "photos",
     "class": "fi-camera",
@@ -5138,6 +5780,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "check",
     "tags": "",
     "class": "fi-check",
@@ -5146,6 +5789,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "checkbox",
     "tags": "",
     "class": "fi-checkbox",
@@ -5154,6 +5798,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "clipboard",
     "tags": "",
     "class": "fi-clipboard",
@@ -5162,6 +5807,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "clipboard-notes",
     "tags": "",
     "class": "fi-clipboard-notes",
@@ -5170,6 +5816,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "clipboard-pencil",
     "tags": "",
     "class": "fi-clipboard-pencil",
@@ -5178,6 +5825,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "clock",
     "tags": "timer",
     "class": "fi-clock",
@@ -5186,6 +5834,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "closed-caption",
     "tags": "",
     "class": "fi-closed-caption",
@@ -5194,6 +5843,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "cloud",
     "tags": "weather",
     "class": "fi-cloud",
@@ -5202,6 +5852,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "comment",
     "tags": "chat bubble",
     "class": "fi-comment",
@@ -5210,6 +5861,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "comment-minus",
     "tags": "chat bubble, delete, remove",
     "class": "fi-comment-minus",
@@ -5218,6 +5870,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "comment-quotes",
     "tags": "chat bubble",
     "class": "fi-comment-quotes",
@@ -5226,6 +5879,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "comment-video",
     "tags": "chat bubble",
     "class": "fi-comment-video",
@@ -5234,6 +5888,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "comments",
     "tags": "chat bubble",
     "class": "fi-comments",
@@ -5242,6 +5897,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "compass",
     "tags": "map, directions",
     "class": "fi-compass",
@@ -5250,6 +5906,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "contrast",
     "tags": "adjust",
     "class": "fi-contrast",
@@ -5258,6 +5915,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "credit-card",
     "tags": "payment",
     "class": "fi-credit-card",
@@ -5266,6 +5924,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "crop",
     "tags": "",
     "class": "fi-crop",
@@ -5274,6 +5933,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "crown",
     "tags": "king, royal",
     "class": "fi-crown",
@@ -5282,6 +5942,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "css3",
     "tags": "brand, logo",
     "class": "fi-css3",
@@ -5290,6 +5951,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "database",
     "tags": "",
     "class": "fi-database",
@@ -5298,6 +5960,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "die-five",
     "tags": "game",
     "class": "fi-die-five",
@@ -5306,6 +5969,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "die-four",
     "tags": "game",
     "class": "fi-die-four",
@@ -5314,6 +5978,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "die-one",
     "tags": "game",
     "class": "fi-die-one",
@@ -5322,6 +5987,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "die-six",
     "tags": "game",
     "class": "fi-die-six",
@@ -5330,6 +5996,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "die-three",
     "tags": "game",
     "class": "fi-die-three",
@@ -5338,6 +6005,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "die-two",
     "tags": "game",
     "class": "fi-die-two",
@@ -5346,6 +6014,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "dislike",
     "tags": "rating, thumbs down",
     "class": "fi-dislike",
@@ -5354,6 +6023,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "dollar-bill",
     "tags": "money",
     "class": "fi-dollar-bill",
@@ -5362,6 +6032,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "dollar",
     "tags": "money, currency",
     "class": "fi-dollar",
@@ -5370,6 +6041,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "download",
     "tags": "",
     "class": "fi-download",
@@ -5378,6 +6050,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "eject",
     "tags": "",
     "class": "fi-eject",
@@ -5386,6 +6059,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "elevator",
     "tags": "",
     "class": "fi-elevator",
@@ -5394,6 +6068,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "euro",
     "tags": "money, currency",
     "class": "fi-euro",
@@ -5402,6 +6077,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "eye",
     "tags": "view",
     "class": "fi-eye",
@@ -5410,6 +6086,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "fast-forward",
     "tags": "",
     "class": "fi-fast-forward",
@@ -5418,6 +6095,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "female-symbol",
     "tags": "gender, venus",
     "class": "fi-female-symbol",
@@ -5426,6 +6104,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "female",
     "tags": "gender",
     "class": "fi-female",
@@ -5434,6 +6113,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "filter",
     "tags": "",
     "class": "fi-filter",
@@ -5442,6 +6122,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "first-aid",
     "tags": "medical, health, hospital",
     "class": "fi-first-aid",
@@ -5450,6 +6131,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "flag",
     "tags": "",
     "class": "fi-flag",
@@ -5458,6 +6140,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "folder",
     "tags": "",
     "class": "fi-folder",
@@ -5466,6 +6149,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "folder-lock",
     "tags": "",
     "class": "fi-folder-lock",
@@ -5474,6 +6158,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "folder-add",
     "tags": "",
     "class": "fi-folder-add",
@@ -5482,6 +6167,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "foot",
     "tags": "print",
     "class": "fi-foot",
@@ -5490,6 +6176,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "foundation",
     "tags": "",
     "class": "fi-foundation",
@@ -5498,6 +6185,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "graph-bar",
     "tags": "",
     "class": "fi-graph-bar",
@@ -5506,6 +6194,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "graph-horizontal",
     "tags": "",
     "class": "fi-graph-horizontal",
@@ -5514,6 +6203,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "graph-pie",
     "tags": "chart",
     "class": "fi-graph-pie",
@@ -5522,6 +6212,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "graph-trend",
     "tags": "",
     "class": "fi-graph-trend",
@@ -5530,6 +6221,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "guide-dog",
     "tags": "blind",
     "class": "fi-guide-dog",
@@ -5538,6 +6230,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "hearing-aid",
     "tags": "deaf, ear",
     "class": "fi-hearing-aid",
@@ -5546,6 +6239,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "heart",
     "tags": "love",
     "class": "fi-heart",
@@ -5554,6 +6248,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "home",
     "tags": "house",
     "class": "fi-home",
@@ -5562,6 +6257,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "html5",
     "tags": "brand, logo",
     "class": "fi-html5",
@@ -5570,6 +6266,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "indent-less",
     "tags": "text",
     "class": "fi-indent-less",
@@ -5578,6 +6275,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "indent-more",
     "tags": "text",
     "class": "fi-indent-more",
@@ -5586,6 +6284,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "info",
     "tags": "",
     "class": "fi-info",
@@ -5594,6 +6293,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "italic",
     "tags": "text",
     "class": "fi-italic",
@@ -5602,6 +6302,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "key",
     "tags": "",
     "class": "fi-key",
@@ -5610,6 +6311,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "laptop",
     "tags": "computer",
     "class": "fi-laptop",
@@ -5618,6 +6320,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "layout",
     "tags": "",
     "class": "fi-layout",
@@ -5626,6 +6329,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "lightbulb",
     "tags": "",
     "class": "fi-lightbulb",
@@ -5634,6 +6338,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "like",
     "tags": "rating, thumbs up",
     "class": "fi-like",
@@ -5642,6 +6347,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "link",
     "tags": "chain",
     "class": "fi-link",
@@ -5650,6 +6356,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "list-bullet",
     "tags": "text",
     "class": "fi-list-bullet",
@@ -5658,6 +6365,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "list-number",
     "tags": "text",
     "class": "fi-list-number",
@@ -5666,6 +6374,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "list-thumbnails",
     "tags": "",
     "class": "fi-list-thumbnails",
@@ -5674,6 +6383,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "list",
     "tags": "",
     "class": "fi-list",
@@ -5682,6 +6392,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "lock",
     "tags": "",
     "class": "fi-lock",
@@ -5690,6 +6401,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "loop",
     "tags": "refresh, reload",
     "class": "fi-loop",
@@ -5698,6 +6410,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "magnifying-glass",
     "tags": "find, search",
     "class": "fi-magnifying-glass",
@@ -5706,6 +6419,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "mail",
     "tags": "envelope",
     "class": "fi-mail",
@@ -5714,6 +6428,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "male-female",
     "tags": "genders",
     "class": "fi-male-female",
@@ -5722,6 +6437,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "male-symbol",
     "tags": "gender, mars",
     "class": "fi-male-symbol",
@@ -5730,6 +6446,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "male",
     "tags": "gender",
     "class": "fi-male",
@@ -5738,6 +6455,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "map",
     "tags": "directions",
     "class": "fi-map",
@@ -5746,6 +6464,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "marker",
     "tags": "map",
     "class": "fi-marker",
@@ -5754,6 +6473,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "megaphone",
     "tags": "bullhorn",
     "class": "fi-megaphone",
@@ -5762,6 +6482,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "microphone",
     "tags": "",
     "class": "fi-microphone",
@@ -5770,6 +6491,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "minus",
     "tags": "subtract",
     "class": "fi-minus",
@@ -5778,6 +6500,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "minus-circle",
     "tags": "remove",
     "class": "fi-minus-circle",
@@ -5786,6 +6509,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "mobile-signal",
     "tags": "smartphone",
     "class": "fi-mobile-signal",
@@ -5794,6 +6518,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "mobile",
     "tags": "smartphone",
     "class": "fi-mobile",
@@ -5802,6 +6527,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "monitor",
     "tags": "display",
     "class": "fi-monitor",
@@ -5810,6 +6536,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "mountains",
     "tags": "",
     "class": "fi-mountains",
@@ -5818,6 +6545,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "music",
     "tags": "",
     "class": "fi-music",
@@ -5826,6 +6554,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "next",
     "tags": "",
     "class": "fi-next",
@@ -5834,6 +6563,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "no-dogs",
     "tags": "pets",
     "class": "fi-no-dogs",
@@ -5842,6 +6572,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "no-smoking",
     "tags": "",
     "class": "fi-no-smoking",
@@ -5850,6 +6581,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "page",
     "tags": "",
     "class": "fi-page",
@@ -5858,6 +6590,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "page-add",
     "tags": "",
     "class": "fi-page-add",
@@ -5866,6 +6599,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "page-copy",
     "tags": "clone, documents, duplicate, files",
     "class": "fi-page-copy",
@@ -5874,6 +6608,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "page-csv",
     "tags": "",
     "class": "fi-page-csv",
@@ -5882,6 +6617,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "page-delete",
     "tags": "",
     "class": "fi-page-delete",
@@ -5890,6 +6626,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "page-doc",
     "tags": "",
     "class": "fi-page-doc",
@@ -5898,6 +6635,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "page-edit",
     "tags": "",
     "class": "fi-page-edit",
@@ -5906,6 +6644,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "page-export-csv",
     "tags": "",
     "class": "fi-page-export-csv",
@@ -5914,6 +6653,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "page-export-doc",
     "tags": "",
     "class": "fi-page-export-doc",
@@ -5922,6 +6662,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "page-export-pdf",
     "tags": "",
     "class": "fi-page-export-pdf",
@@ -5930,6 +6671,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "page-export",
     "tags": "",
     "class": "fi-page-export",
@@ -5938,6 +6680,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "page-filled",
     "tags": "",
     "class": "fi-page-filled",
@@ -5946,6 +6689,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "page-multiple",
     "tags": "",
     "class": "fi-page-multiple",
@@ -5954,6 +6698,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "page-pdf",
     "tags": "",
     "class": "fi-page-pdf",
@@ -5962,6 +6707,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "page-remove",
     "tags": "",
     "class": "fi-page-remove",
@@ -5970,6 +6716,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "page-search",
     "tags": "",
     "class": "fi-page-search",
@@ -5978,6 +6725,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "paint-bucket",
     "tags": "fill, pour",
     "class": "fi-paint-bucket",
@@ -5986,6 +6734,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "paperclip",
     "tags": "attachment",
     "class": "fi-paperclip",
@@ -5994,6 +6743,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "pause",
     "tags": "",
     "class": "fi-pause",
@@ -6002,6 +6752,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "paw",
     "tags": "animal, pet, print",
     "class": "fi-paw",
@@ -6010,6 +6761,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "paypal",
     "tags": "payment",
     "class": "fi-paypal",
@@ -6018,6 +6770,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "pencil",
     "tags": "",
     "class": "fi-pencil",
@@ -6026,6 +6779,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "photo",
     "tags": "",
     "class": "fi-photo",
@@ -6034,6 +6788,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "play",
     "tags": "",
     "class": "fi-play",
@@ -6042,6 +6797,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "play-circle",
     "tags": "",
     "class": "fi-play-circle",
@@ -6050,6 +6806,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "play-video",
     "tags": "",
     "class": "fi-play-video",
@@ -6058,6 +6815,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "plus",
     "tags": "add",
     "class": "fi-plus",
@@ -6066,6 +6824,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "pound",
     "tags": "money, currency",
     "class": "fi-pound",
@@ -6074,6 +6833,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "power",
     "tags": "",
     "class": "fi-power",
@@ -6082,6 +6842,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "previous",
     "tags": "",
     "class": "fi-previous",
@@ -6090,6 +6851,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "price-tag",
     "tags": "",
     "class": "fi-price-tag",
@@ -6098,6 +6860,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "pricetag-multiple",
     "tags": "",
     "class": "fi-pricetag-multiple",
@@ -6106,6 +6869,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "print",
     "tags": "",
     "class": "fi-print",
@@ -6114,6 +6878,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "prohibited",
     "tags": "ban",
     "class": "fi-prohibited",
@@ -6122,6 +6887,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "projection-screen",
     "tags": "presentation",
     "class": "fi-projection-screen",
@@ -6130,6 +6896,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "puzzle",
     "tags": "game, jigsaw",
     "class": "fi-puzzle",
@@ -6138,6 +6905,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "quote",
     "tags": "text",
     "class": "fi-quote",
@@ -6146,6 +6914,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "record",
     "tags": "",
     "class": "fi-record",
@@ -6154,6 +6923,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "refresh",
     "tags": "reload",
     "class": "fi-refresh",
@@ -6162,6 +6932,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "results",
     "tags": "",
     "class": "fi-results",
@@ -6170,6 +6941,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "results-demographics",
     "tags": "",
     "class": "fi-results-demographics",
@@ -6178,6 +6950,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "rewind",
     "tags": "",
     "class": "fi-rewind",
@@ -6186,6 +6959,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "rewind-ten",
     "tags": "",
     "class": "fi-rewind-ten",
@@ -6194,6 +6968,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "rss",
     "tags": "",
     "class": "fi-rss",
@@ -6202,6 +6977,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "safety-cone",
     "tags": "",
     "class": "fi-safety-cone",
@@ -6210,6 +6986,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "save",
     "tags": "floppy disk",
     "class": "fi-save",
@@ -6218,6 +6995,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "share",
     "tags": "",
     "class": "fi-share",
@@ -6226,6 +7004,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "sheriff-badge",
     "tags": "",
     "class": "fi-sheriff-badge",
@@ -6234,6 +7013,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "shield",
     "tags": "",
     "class": "fi-shield",
@@ -6242,6 +7022,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "shopping-bag",
     "tags": "",
     "class": "fi-shopping-bag",
@@ -6250,6 +7031,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "shopping-cart",
     "tags": "",
     "class": "fi-shopping-cart",
@@ -6258,6 +7040,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "shuffle",
     "tags": "random",
     "class": "fi-shuffle",
@@ -6266,6 +7049,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "skull",
     "tags": "danger, poison, warning",
     "class": "fi-skull",
@@ -6274,6 +7058,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "social-500px",
     "tags": "brand, logo",
     "class": "fi-social-500px",
@@ -6282,6 +7067,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "social-adobe",
     "tags": "brand, logo",
     "class": "fi-social-adobe",
@@ -6290,6 +7076,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "social-amazon",
     "tags": "brand, logo",
     "class": "fi-social-amazon",
@@ -6298,6 +7085,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "social-android",
     "tags": "brand, logo",
     "class": "fi-social-android",
@@ -6306,6 +7094,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "social-apple",
     "tags": "brand, logo",
     "class": "fi-social-apple",
@@ -6314,6 +7103,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "social-behance",
     "tags": "brand, logo",
     "class": "fi-social-behance",
@@ -6322,6 +7112,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "social-bing",
     "tags": "brand, logo",
     "class": "fi-social-bing",
@@ -6330,6 +7121,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "social-blogger",
     "tags": "brand, logo",
     "class": "fi-social-blogger",
@@ -6338,6 +7130,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "social-delicious",
     "tags": "brand, logo",
     "class": "fi-social-delicious",
@@ -6346,6 +7139,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "social-designer-news",
     "tags": "brand, logo",
     "class": "fi-social-designer-news",
@@ -6354,6 +7148,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "social-deviant-art",
     "tags": "brand, logo",
     "class": "fi-social-deviant-art",
@@ -6362,6 +7157,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "social-digg",
     "tags": "brand, logo",
     "class": "fi-social-digg",
@@ -6370,6 +7166,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "social-dribbble",
     "tags": "brand, logo",
     "class": "fi-social-dribbble",
@@ -6378,6 +7175,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "social-drive",
     "tags": "brand, logo",
     "class": "fi-social-drive",
@@ -6386,6 +7184,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "social-dropbox",
     "tags": "brand, logo",
     "class": "fi-social-dropbox",
@@ -6394,6 +7193,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "social-evernote",
     "tags": "brand, logo",
     "class": "fi-social-evernote",
@@ -6402,6 +7202,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "social-facebook",
     "tags": "brand, logo",
     "class": "fi-social-facebook",
@@ -6410,6 +7211,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "social-flickr",
     "tags": "brand, logo",
     "class": "fi-social-flickr",
@@ -6418,6 +7220,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "social-forrst",
     "tags": "brand, logo",
     "class": "fi-social-forrst",
@@ -6426,6 +7229,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "social-foursquare",
     "tags": "brand, logo",
     "class": "fi-social-foursquare",
@@ -6434,6 +7238,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "social-game-center",
     "tags": "brand, logo",
     "class": "fi-social-game-center",
@@ -6442,6 +7247,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "social-github",
     "tags": "brand, logo",
     "class": "fi-social-github",
@@ -6450,6 +7256,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "social-google-plus",
     "tags": "brand, logo",
     "class": "fi-social-google-plus",
@@ -6458,6 +7265,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "social-hacker-news",
     "tags": "brand, logo",
     "class": "fi-social-hacker-news",
@@ -6466,6 +7274,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "social-hi5",
     "tags": "brand, logo",
     "class": "fi-social-hi5",
@@ -6474,6 +7283,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "social-instagram",
     "tags": "brand, logo",
     "class": "fi-social-instagram",
@@ -6482,6 +7292,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "social-joomla",
     "tags": "brand, logo",
     "class": "fi-social-joomla",
@@ -6490,6 +7301,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "social-lastfm",
     "tags": "brand, logo",
     "class": "fi-social-lastfm",
@@ -6498,6 +7310,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "social-linkedin",
     "tags": "brand, logo",
     "class": "fi-social-linkedin",
@@ -6506,6 +7319,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "social-medium",
     "tags": "brand, logo",
     "class": "fi-social-medium",
@@ -6514,6 +7328,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "social-myspace",
     "tags": "brand, logo",
     "class": "fi-social-myspace",
@@ -6522,6 +7337,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "social-orkut",
     "tags": "brand, logo",
     "class": "fi-social-orkut",
@@ -6530,6 +7346,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "social-path",
     "tags": "brand, logo",
     "class": "fi-social-path",
@@ -6538,6 +7355,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "social-picasa",
     "tags": "brand, logo",
     "class": "fi-social-picasa",
@@ -6546,6 +7364,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "social-pinterest",
     "tags": "brand, logo",
     "class": "fi-social-pinterest",
@@ -6554,6 +7373,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "social-rdio",
     "tags": "brand, logo",
     "class": "fi-social-rdio",
@@ -6562,6 +7382,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "social-reddit",
     "tags": "brand, logo",
     "class": "fi-social-reddit",
@@ -6570,6 +7391,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "social-skype",
     "tags": "brand, logo",
     "class": "fi-social-skype",
@@ -6578,6 +7400,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "social-skillshare",
     "tags": "brand, logo",
     "class": "fi-social-skillshare",
@@ -6586,6 +7409,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "social-smashing-mag",
     "tags": "brand, logo",
     "class": "fi-social-smashing-mag",
@@ -6594,6 +7418,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "social-snapchat",
     "tags": "brand, logo",
     "class": "fi-social-snapchat",
@@ -6602,6 +7427,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "social-spotify",
     "tags": "brand, logo",
     "class": "fi-social-spotify",
@@ -6610,6 +7436,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "social-squidoo",
     "tags": "brand, logo",
     "class": "fi-social-squidoo",
@@ -6618,6 +7445,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "social-stack-overflow",
     "tags": "brand, logo",
     "class": "fi-social-stack-overflow",
@@ -6626,6 +7454,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "social-steam",
     "tags": "brand, logo",
     "class": "fi-social-steam",
@@ -6634,6 +7463,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "social-stumbleupon",
     "tags": "brand, logo",
     "class": "fi-social-stumbleupon",
@@ -6642,6 +7472,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "social-treehouse",
     "tags": "brand, logo",
     "class": "fi-social-treehouse",
@@ -6650,6 +7481,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "social-tumblr",
     "tags": "brand, logo",
     "class": "fi-social-tumblr",
@@ -6658,6 +7490,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "social-twitter",
     "tags": "brand, logo",
     "class": "fi-social-twitter",
@@ -6666,6 +7499,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "social-vimeo",
     "tags": "brand, logo",
     "class": "fi-social-vimeo",
@@ -6674,6 +7508,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "social-windows",
     "tags": "brand, logo",
     "class": "fi-social-windows",
@@ -6682,6 +7517,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "social-xbox",
     "tags": "brand, logo",
     "class": "fi-social-xbox",
@@ -6690,6 +7526,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "social-yahoo",
     "tags": "brand, logo",
     "class": "fi-social-yahoo",
@@ -6698,6 +7535,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "social-yelp",
     "tags": "brand, logo",
     "class": "fi-social-yelp",
@@ -6706,6 +7544,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "social-youtube",
     "tags": "brand, logo",
     "class": "fi-social-youtube",
@@ -6714,6 +7553,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "social-zerply",
     "tags": "brand, logo",
     "class": "fi-social-zerply",
@@ -6722,6 +7562,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "social-zurb",
     "tags": "brand, logo",
     "class": "fi-social-zurb",
@@ -6730,6 +7571,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "sound",
     "tags": "audio",
     "class": "fi-sound",
@@ -6738,6 +7580,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "star",
     "tags": "rating",
     "class": "fi-star",
@@ -6746,6 +7589,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "stop",
     "tags": "",
     "class": "fi-stop",
@@ -6754,6 +7598,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "strikethrough",
     "tags": "text",
     "class": "fi-strikethrough",
@@ -6762,6 +7607,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "subscript",
     "tags": "text",
     "class": "fi-subscript",
@@ -6770,6 +7616,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "superscript",
     "tags": "text",
     "class": "fi-superscript",
@@ -6778,6 +7625,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "tablet-portrait",
     "tags": "ipad",
     "class": "fi-tablet-portrait",
@@ -6786,6 +7634,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "tablet-landscape",
     "tags": "ipad",
     "class": "fi-tablet-landscape",
@@ -6794,6 +7643,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "target",
     "tags": "bullseye",
     "class": "fi-target",
@@ -6802,6 +7652,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "target-two",
     "tags": "aim, reticle",
     "class": "fi-target-two",
@@ -6810,6 +7661,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "telephone",
     "tags": "",
     "class": "fi-telephone",
@@ -6818,6 +7670,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "telephone-accessible",
     "tags": "",
     "class": "fi-telephone-accessible",
@@ -6826,6 +7679,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "text-color",
     "tags": "",
     "class": "fi-text-color",
@@ -6834,6 +7688,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "thumbnails",
     "tags": "",
     "class": "fi-thumbnails",
@@ -6842,6 +7697,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "ticket",
     "tags": "",
     "class": "fi-ticket",
@@ -6850,6 +7706,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "trees",
     "tags": "nature",
     "class": "fi-trees",
@@ -6858,6 +7715,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "torso",
     "tags": "user, person",
     "class": "fi-torso",
@@ -6866,6 +7724,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "torsos-all",
     "tags": "users, people",
     "class": "fi-torsos-all",
@@ -6874,6 +7733,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "torsos-all-female",
     "tags": "",
     "class": "fi-torsos-all-female",
@@ -6882,6 +7742,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "torso-business",
     "tags": "user, person",
     "class": "fi-torso-business",
@@ -6890,6 +7751,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "torso-female",
     "tags": "user, person",
     "class": "fi-torso-female",
@@ -6898,6 +7760,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "torsos",
     "tags": "users, people",
     "class": "fi-torsos",
@@ -6906,6 +7769,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "torsos-female-male",
     "tags": "users, people",
     "class": "fi-torsos-female-male",
@@ -6914,6 +7778,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "torsos-male-female",
     "tags": "users, people",
     "class": "fi-torsos-male-female",
@@ -6922,6 +7787,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "trash",
     "tags": "delete",
     "class": "fi-trash",
@@ -6930,6 +7796,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "trophy",
     "tags": "prize, award",
     "class": "fi-trophy",
@@ -6938,6 +7805,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "underline",
     "tags": "text",
     "class": "fi-underline",
@@ -6946,6 +7814,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "universal-access",
     "tags": "",
     "class": "fi-universal-access",
@@ -6954,6 +7823,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "unlink",
     "tags": "chain",
     "class": "fi-unlink",
@@ -6962,6 +7832,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "unlock",
     "tags": "",
     "class": "fi-unlock",
@@ -6970,6 +7841,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "upload",
     "tags": "",
     "class": "fi-upload",
@@ -6978,6 +7850,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "upload-cloud",
     "tags": "",
     "class": "fi-upload-cloud",
@@ -6986,6 +7859,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "usb",
     "tags": "",
     "class": "fi-usb",
@@ -6994,6 +7868,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "video",
     "tags": "camera",
     "class": "fi-video",
@@ -7002,6 +7877,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "volume",
     "tags": "",
     "class": "fi-volume",
@@ -7010,6 +7886,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "volume-none",
     "tags": "",
     "class": "fi-volume-none",
@@ -7018,6 +7895,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "volume-strike",
     "tags": "",
     "class": "fi-volume-strike",
@@ -7026,6 +7904,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "web",
     "tags": "earth, planet, globe",
     "class": "fi-web",
@@ -7034,6 +7913,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "wheelchair",
     "tags": "handicap",
     "class": "fi-wheelchair",
@@ -7042,6 +7922,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "widget",
     "tags": "gear, cog, settings",
     "class": "fi-widget",
@@ -7050,6 +7931,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "wrench",
     "tags": "tools",
     "class": "fi-wrench",
@@ -7058,6 +7940,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "x",
     "tags": "close",
     "class": "fi-x",
@@ -7066,6 +7949,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "x-circle",
     "tags": "delete, remove",
     "class": "fi-x-circle",
@@ -7074,6 +7958,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "yen",
     "tags": "money, currency",
     "class": "fi-yen",
@@ -7082,6 +7967,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "zoom-in",
     "tags": "magnifying glass",
     "class": "fi-zoom-in",
@@ -7090,6 +7976,7 @@
   },
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "zoom-out",
     "tags": "magnifying glass",
     "class": "fi-zoom-out",
@@ -7099,6 +7986,7 @@
 
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "adjust",
     "tags": "contrast",
     "class": "glyphicon glyphicon-adjust",
@@ -7107,6 +7995,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "alert",
     "tags": "warning, caution, sign",
     "class": "glyphicon glyphicon-alert",
@@ -7115,6 +8004,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "align-center",
     "tags": "text editor",
     "class": "glyphicon glyphicon-align-center",
@@ -7123,6 +8013,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "align-justify",
     "tags": "text editor",
     "class": "glyphicon glyphicon-align-justify",
@@ -7131,6 +8022,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "align-left",
     "tags": "text editor",
     "class": "glyphicon glyphicon-align-left",
@@ -7139,6 +8031,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "align-right",
     "tags": "text editor",
     "class": "glyphicon glyphicon-align-right",
@@ -7147,6 +8040,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "apple",
     "tags": "food, fruit",
     "class": "glyphicon glyphicon-apple",
@@ -7155,6 +8049,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "arrow-down",
     "tags": "directional",
     "class": "glyphicon glyphicon-arrow-down",
@@ -7163,6 +8058,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "arrow-left",
     "tags": "directional",
     "class": "glyphicon glyphicon-arrow-left",
@@ -7171,6 +8067,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "arrow-right",
     "tags": "directional",
     "class": "glyphicon glyphicon-arrow-right",
@@ -7179,6 +8076,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "arrow-up",
     "tags": "directional",
     "class": "glyphicon glyphicon-arrow-up",
@@ -7187,6 +8085,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "asterisk",
     "tags": "",
     "class": "glyphicon glyphicon-asterisk",
@@ -7195,6 +8094,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "baby-formula",
     "tags": "bottle, milk",
     "class": "glyphicon glyphicon-baby-formula",
@@ -7203,6 +8103,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "backward",
     "tags": "video player",
     "class": "glyphicon glyphicon-backward",
@@ -7211,6 +8112,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "ban-circle",
     "tags": "prohibited",
     "class": "glyphicon glyphicon-ban-circle",
@@ -7219,6 +8121,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "barcode",
     "tags": "",
     "class": "glyphicon glyphicon-barcode",
@@ -7227,6 +8130,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "bed",
     "tags": "sleep, hotel",
     "class": "glyphicon glyphicon-bed",
@@ -7235,6 +8139,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "bell",
     "tags": "audio, sound",
     "class": "glyphicon glyphicon-bell",
@@ -7243,6 +8148,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "bishop",
     "tags": "chess, game",
     "class": "glyphicon glyphicon-bishop",
@@ -7251,6 +8157,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "bitcoin",
     "tags": "currency",
     "class": "glyphicon glyphicon-bitcoin",
@@ -7259,6 +8166,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "blackboard",
     "tags": "screen",
     "class": "glyphicon glyphicon-blackboard",
@@ -7267,6 +8175,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "bold",
     "tags": "text editor",
     "class": "glyphicon glyphicon-bold",
@@ -7275,6 +8184,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "book",
     "tags": "",
     "class": "glyphicon glyphicon-book",
@@ -7283,6 +8193,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "bookmark",
     "tags": "",
     "class": "glyphicon glyphicon-bookmark",
@@ -7291,6 +8202,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "briefcase",
     "tags": "suitcase, business",
     "class": "glyphicon glyphicon-briefcase",
@@ -7299,6 +8211,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "bullhorn",
     "tags": "speakerphone",
     "class": "glyphicon glyphicon-bullhorn",
@@ -7307,6 +8220,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "calendar",
     "tags": "date",
     "class": "glyphicon glyphicon-calendar",
@@ -7315,6 +8229,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "camera",
     "tags": "photographs",
     "class": "glyphicon glyphicon-camera",
@@ -7323,6 +8238,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "cd",
     "tags": "music, disc, vinyl",
     "class": "glyphicon glyphicon-cd",
@@ -7331,6 +8247,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "certificate",
     "tags": "seal, prize, award",
     "class": "glyphicon glyphicon-certificate",
@@ -7339,6 +8256,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "check",
     "tags": "form control",
     "class": "glyphicon glyphicon-check",
@@ -7347,6 +8265,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "chevron-down",
     "tags": "angle, directional",
     "class": "glyphicon glyphicon-chevron-down",
@@ -7355,6 +8274,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "chevron-left",
     "tags": "angle, directional",
     "class": "glyphicon glyphicon-chevron-left",
@@ -7363,6 +8283,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "chevron-right",
     "tags": "angle, directional",
     "class": "glyphicon glyphicon-chevron-right",
@@ -7371,6 +8292,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "chevron-up",
     "tags": "angle, directional",
     "class": "glyphicon glyphicon-chevron-up",
@@ -7379,6 +8301,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "circle-arrow-down",
     "tags": "directional",
     "class": "glyphicon glyphicon-circle-arrow-down",
@@ -7387,6 +8310,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "circle-arrow-left",
     "tags": "directional",
     "class": "glyphicon glyphicon-circle-arrow-left",
@@ -7395,6 +8319,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "circle-arrow-right",
     "tags": "directional",
     "class": "glyphicon glyphicon-circle-arrow-right",
@@ -7403,6 +8328,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "circle-arrow-up",
     "tags": "directional",
     "class": "glyphicon glyphicon-circle-arrow-up",
@@ -7411,6 +8337,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "cloud",
     "tags": "weather",
     "class": "glyphicon glyphicon-cloud",
@@ -7419,6 +8346,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "cloud-download",
     "tags": "",
     "class": "glyphicon glyphicon-cloud-download",
@@ -7427,6 +8355,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "cloud-upload",
     "tags": "",
     "class": "glyphicon glyphicon-cloud-upload",
@@ -7435,6 +8364,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "cog",
     "tags": "gear, settings",
     "class": "glyphicon glyphicon-cog",
@@ -7443,6 +8373,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "collapse-down",
     "tags": "directional",
     "class": "glyphicon glyphicon-collapse-down",
@@ -7451,6 +8382,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "collapse-up",
     "tags": "directional",
     "class": "glyphicon glyphicon-collapse-up",
@@ -7459,6 +8391,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "comment",
     "tags": "chat, speech bubble",
     "class": "glyphicon glyphicon-comment",
@@ -7467,6 +8400,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "compressed",
     "tags": "",
     "class": "glyphicon glyphicon-compressed",
@@ -7475,6 +8409,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "console",
     "tags": "terminal",
     "class": "glyphicon glyphicon-console",
@@ -7483,6 +8418,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "copy",
     "tags": "clipboard",
     "class": "glyphicon glyphicon-copy",
@@ -7491,6 +8427,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "copyright-mark",
     "tags": "",
     "class": "glyphicon glyphicon-copyright-mark",
@@ -7499,6 +8436,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "credit-card",
     "tags": "money, payment",
     "class": "glyphicon glyphicon-credit-card",
@@ -7507,6 +8445,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "cutlery",
     "tags": "food, fork, knife",
     "class": "glyphicon glyphicon-cutlery",
@@ -7515,6 +8454,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "dashboard",
     "tags": "tachometer, speedometer",
     "class": "glyphicon glyphicon-dashboard",
@@ -7523,6 +8463,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "door",
     "tags": "",
     "class": "glyphicon glyphicon-door",
@@ -7531,6 +8472,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "download",
     "tags": "",
     "class": "glyphicon glyphicon-download",
@@ -7539,6 +8481,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "download-alt",
     "tags": "",
     "class": "glyphicon glyphicon-download-alt",
@@ -7547,6 +8490,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "duplicate",
     "tags": "clone, copy, documents, files",
     "class": "glyphicon glyphicon-duplicate",
@@ -7555,6 +8499,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "earphone",
     "tags": "telephone",
     "class": "glyphicon glyphicon-earphone",
@@ -7563,6 +8508,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "edit",
     "tags": "text editor",
     "class": "glyphicon glyphicon-edit",
@@ -7571,6 +8517,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "education",
     "tags": "hat, graduation",
     "class": "glyphicon glyphicon-education",
@@ -7579,6 +8526,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "eject",
     "tags": "",
     "class": "glyphicon glyphicon-eject",
@@ -7587,6 +8535,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "envelope",
     "tags": "email",
     "class": "glyphicon glyphicon-envelope",
@@ -7595,6 +8544,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "equalizer",
     "tags": "levels, settings",
     "class": "glyphicon glyphicon-equalizer",
@@ -7603,6 +8553,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "erase",
     "tags": "delete",
     "class": "glyphicon glyphicon-erase",
@@ -7611,6 +8562,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "euro",
     "tags": "currency, money",
     "class": "glyphicon glyphicon-euro",
@@ -7619,6 +8571,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "exclamation-sign",
     "tags": "",
     "class": "glyphicon glyphicon-exclamation-sign",
@@ -7627,6 +8580,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "expand",
     "tags": "directional",
     "class": "glyphicon glyphicon-expand",
@@ -7635,6 +8589,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "export",
     "tags": "text editor",
     "class": "glyphicon glyphicon-export",
@@ -7643,6 +8598,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "eye-close",
     "tags": "hide",
     "class": "glyphicon glyphicon-eye-close",
@@ -7651,6 +8607,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "eye-open",
     "tags": "show",
     "class": "glyphicon glyphicon-eye-open",
@@ -7659,6 +8616,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "facetime-video",
     "tags": "video player, camera",
     "class": "glyphicon glyphicon-facetime-video",
@@ -7667,6 +8625,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "fast-backward",
     "tags": "video player",
     "class": "glyphicon glyphicon-fast-backward",
@@ -7675,6 +8634,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "fast-forward",
     "tags": "video player",
     "class": "glyphicon glyphicon-fast-forward",
@@ -7683,6 +8643,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "file",
     "tags": "text editor, document",
     "class": "glyphicon glyphicon-file",
@@ -7691,6 +8652,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "film",
     "tags": "movie",
     "class": "glyphicon glyphicon-film",
@@ -7699,6 +8661,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "filter",
     "tags": "",
     "class": "glyphicon glyphicon-filter",
@@ -7707,6 +8670,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "fire",
     "tags": "flame, hot",
     "class": "glyphicon glyphicon-fire",
@@ -7715,6 +8679,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "flag",
     "tags": "",
     "class": "glyphicon glyphicon-flag",
@@ -7723,6 +8688,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "flash",
     "tags": "lightning bolt",
     "class": "glyphicon glyphicon-flash",
@@ -7731,6 +8697,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "floppy-disk",
     "tags": "save",
     "class": "glyphicon glyphicon-floppy-disk",
@@ -7739,6 +8706,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "floppy-open",
     "tags": "disk, save",
     "class": "glyphicon glyphicon-floppy-open",
@@ -7747,6 +8715,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "floppy-remove",
     "tags": "disk, save",
     "class": "glyphicon glyphicon-floppy-remove",
@@ -7755,6 +8724,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "floppy-save",
     "tags": "disk, save",
     "class": "glyphicon glyphicon-floppy-save",
@@ -7763,6 +8733,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "floppy-saved",
     "tags": "disk, save",
     "class": "glyphicon glyphicon-floppy-saved",
@@ -7771,6 +8742,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "folder-close",
     "tags": "text editor",
     "class": "glyphicon glyphicon-folder-close",
@@ -7779,6 +8751,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "folder-open",
     "tags": "text editor",
     "class": "glyphicon glyphicon-folder-open",
@@ -7787,6 +8760,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "font",
     "tags": "text editor",
     "class": "glyphicon glyphicon-font",
@@ -7795,6 +8769,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "forward",
     "tags": "video player",
     "class": "glyphicon glyphicon-forward",
@@ -7803,6 +8778,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "fullscreen",
     "tags": "video player",
     "class": "glyphicon glyphicon-fullscreen",
@@ -7811,6 +8787,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "gbp",
     "tags": "currency, money, pound",
     "class": "glyphicon glyphicon-gbp",
@@ -7819,6 +8796,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "gift",
     "tags": "present",
     "class": "glyphicon glyphicon-gift",
@@ -7827,6 +8805,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "glass",
     "tags": "drink, martini, alcohol, cocktail",
     "class": "glyphicon glyphicon-glass",
@@ -7835,6 +8814,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "globe",
     "tags": "earth, planet, world",
     "class": "glyphicon glyphicon-globe",
@@ -7843,6 +8823,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "grain",
     "tags": "food, plant, wheat",
     "class": "glyphicon glyphicon-grain",
@@ -7851,6 +8832,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "hand-down",
     "tags": "directional, finger, pointer",
     "class": "glyphicon glyphicon-hand-down",
@@ -7859,6 +8841,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "hand-left",
     "tags": "directional, finger, pointer",
     "class": "glyphicon glyphicon-hand-left",
@@ -7867,6 +8850,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "hand-right",
     "tags": "directional, finger, pointer",
     "class": "glyphicon glyphicon-hand-right",
@@ -7875,6 +8859,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "hand-up",
     "tags": "directional, finger, pointer",
     "class": "glyphicon glyphicon-hand-up",
@@ -7883,6 +8868,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "hd-video",
     "tags": "video player",
     "class": "glyphicon glyphicon-hd-video",
@@ -7891,6 +8877,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "hdd",
     "tags": "hard drive, computer, disk",
     "class": "glyphicon glyphicon-hdd",
@@ -7899,6 +8886,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "header",
     "tags": "text editor",
     "class": "glyphicon glyphicon-header",
@@ -7907,6 +8895,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "headphones",
     "tags": "music, audio, sound",
     "class": "glyphicon glyphicon-headphones",
@@ -7915,6 +8904,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "heart",
     "tags": "like, favorite",
     "class": "glyphicon glyphicon-heart",
@@ -7923,6 +8913,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "heart-empty",
     "tags": "unlike, unfavorite",
     "class": "glyphicon glyphicon-heart-empty",
@@ -7931,6 +8922,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "home",
     "tags": "",
     "class": "glyphicon glyphicon-home",
@@ -7939,6 +8931,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "hourglass",
     "tags": "busy, loading, timer",
     "class": "glyphicon glyphicon-hourglass",
@@ -7947,6 +8940,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "ice-lolly",
     "tags": "dessert, popsicle",
     "class": "glyphicon glyphicon-ice-lolly",
@@ -7955,6 +8949,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "ice-lolly-tasted",
     "tags": "dessert, popsicle",
     "class": "glyphicon glyphicon-ice-lolly-tasted",
@@ -7963,6 +8958,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "import",
     "tags": "text editor",
     "class": "glyphicon glyphicon-import",
@@ -7971,6 +8967,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "inbox",
     "tags": "email",
     "class": "glyphicon glyphicon-inbox",
@@ -7979,6 +8976,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "indent-left",
     "tags": "text editor",
     "class": "glyphicon glyphicon-indent-left",
@@ -7987,6 +8985,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "indent-right",
     "tags": "text editor",
     "class": "glyphicon glyphicon-indent-right",
@@ -7995,6 +8994,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "info-sign",
     "tags": "",
     "class": "glyphicon glyphicon-info-sign",
@@ -8003,6 +9003,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "italic",
     "tags": "text editor",
     "class": "glyphicon glyphicon-italic",
@@ -8011,6 +9012,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "key",
     "tags": "security",
     "class": "glyphicon glyphicon-key",
@@ -8019,6 +9021,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "king",
     "tags": "chess, game",
     "class": "glyphicon glyphicon-king",
@@ -8027,6 +9030,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "knight",
     "tags": "chess, game",
     "class": "glyphicon glyphicon-knight",
@@ -8035,6 +9039,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "lamp",
     "tags": "",
     "class": "glyphicon glyphicon-lamp",
@@ -8043,6 +9048,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "leaf",
     "tags": "",
     "class": "glyphicon glyphicon-leaf",
@@ -8051,6 +9057,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "level-up",
     "tags": "folder",
     "class": "glyphicon glyphicon-level-up",
@@ -8059,6 +9066,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "link",
     "tags": "chain",
     "class": "glyphicon glyphicon-link",
@@ -8067,6 +9075,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "list",
     "tags": "text editor",
     "class": "glyphicon glyphicon-list",
@@ -8075,6 +9084,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "list-alt",
     "tags": "text editor",
     "class": "glyphicon glyphicon-list-alt",
@@ -8083,6 +9093,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "lock",
     "tags": "security",
     "class": "glyphicon glyphicon-lock",
@@ -8091,6 +9102,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "log-in",
     "tags": "",
     "class": "glyphicon glyphicon-log-in",
@@ -8099,6 +9111,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "log-out",
     "tags": "",
     "class": "glyphicon glyphicon-log-out",
@@ -8107,6 +9120,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "magnet",
     "tags": "",
     "class": "glyphicon glyphicon-magnet",
@@ -8115,6 +9129,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "map-marker",
     "tags": "location",
     "class": "glyphicon glyphicon-map-marker",
@@ -8123,6 +9138,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "menu-down",
     "tags": "angle, chevron, directional",
     "class": "glyphicon glyphicon-menu-down",
@@ -8131,6 +9147,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "menu-hamburger",
     "tags": "bars, menu, more",
     "class": "glyphicon glyphicon-menu-hamburger",
@@ -8139,6 +9156,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "menu-left",
     "tags": "angle, chevron, directional",
     "class": "glyphicon glyphicon-menu-left",
@@ -8147,6 +9165,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "menu-right",
     "tags": "angle, chevron, directional",
     "class": "glyphicon glyphicon-menu-right",
@@ -8155,6 +9174,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "menu-up",
     "tags": "angle, chevron, directional",
     "class": "glyphicon glyphicon-menu-up",
@@ -8163,6 +9183,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "minus",
     "tags": "",
     "class": "glyphicon glyphicon-minus",
@@ -8171,6 +9192,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "minus-sign",
     "tags": "",
     "class": "glyphicon glyphicon-minus-sign",
@@ -8179,6 +9201,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "modal-window",
     "tags": "",
     "class": "glyphicon glyphicon-modal-window",
@@ -8187,6 +9210,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "move",
     "tags": "",
     "class": "glyphicon glyphicon-move",
@@ -8195,6 +9219,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "music",
     "tags": "",
     "class": "glyphicon glyphicon-music",
@@ -8203,6 +9228,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "new-window",
     "tags": "",
     "class": "glyphicon glyphicon-new-window",
@@ -8211,6 +9237,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "object-align-bottom",
     "tags": "",
     "class": "glyphicon glyphicon-object-align-bottom",
@@ -8219,6 +9246,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "object-align-horizontal",
     "tags": "",
     "class": "glyphicon glyphicon-object-align-horizontal",
@@ -8227,6 +9255,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "object-align-left",
     "tags": "",
     "class": "glyphicon glyphicon-object-align-left",
@@ -8235,6 +9264,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "object-align-right",
     "tags": "",
     "class": "glyphicon glyphicon-object-align-right",
@@ -8243,6 +9273,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "object-align-top",
     "tags": "",
     "class": "glyphicon glyphicon-object-align-top",
@@ -8251,6 +9282,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "object-align-vertical",
     "tags": "",
     "class": "glyphicon glyphicon-object-align-vertical",
@@ -8259,6 +9291,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "off",
     "tags": "on, power",
     "class": "glyphicon glyphicon-off",
@@ -8267,6 +9300,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "oil",
     "tags": "barrel",
     "class": "glyphicon glyphicon-oil",
@@ -8275,6 +9309,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "ok",
     "tags": "checkmark",
     "class": "glyphicon glyphicon-ok",
@@ -8283,6 +9318,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "ok-circle",
     "tags": "checkmark",
     "class": "glyphicon glyphicon-ok-circle",
@@ -8291,6 +9327,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "ok-sign",
     "tags": "checkmark",
     "class": "glyphicon glyphicon-ok-sign",
@@ -8299,6 +9336,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "open",
     "tags": "text editor",
     "class": "glyphicon glyphicon-open",
@@ -8307,6 +9345,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "open-file",
     "tags": "",
     "class": "glyphicon glyphicon-open-file",
@@ -8315,6 +9354,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "option-horizontal",
     "tags": "more",
     "class": "glyphicon glyphicon-option-horizontal",
@@ -8323,6 +9363,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "option-vertical",
     "tags": "more",
     "class": "glyphicon glyphicon-option-vertical",
@@ -8331,6 +9372,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "paperclip",
     "tags": "text editor, email, file attachment",
     "class": "glyphicon glyphicon-paperclip",
@@ -8339,6 +9381,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "paste",
     "tags": "clipboard",
     "class": "glyphicon glyphicon-paste",
@@ -8347,6 +9390,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "pause",
     "tags": "",
     "class": "glyphicon glyphicon-pause",
@@ -8355,6 +9399,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "pawn",
     "tags": "chess, game",
     "class": "glyphicon glyphicon-pawn",
@@ -8363,6 +9408,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "pencil",
     "tags": "",
     "class": "glyphicon glyphicon-pencil",
@@ -8371,6 +9417,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "phone",
     "tags": "mobile",
     "class": "glyphicon glyphicon-phone",
@@ -8379,6 +9426,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "phone-alt",
     "tags": "telephone",
     "class": "glyphicon glyphicon-phone-alt",
@@ -8387,6 +9435,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "picture",
     "tags": "text editor",
     "class": "glyphicon glyphicon-picture",
@@ -8395,6 +9444,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "piggy-bank",
     "tags": "savings",
     "class": "glyphicon glyphicon-piggy-bank",
@@ -8403,6 +9453,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "plane",
     "tags": "airplane, jet, transportation",
     "class": "glyphicon glyphicon-plane",
@@ -8411,6 +9462,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "play",
     "tags": "video player, triangle",
     "class": "glyphicon glyphicon-play",
@@ -8419,6 +9471,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "play-circle",
     "tags": "video player",
     "class": "glyphicon glyphicon-play-circle",
@@ -8427,6 +9480,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "plus",
     "tags": "add",
     "class": "glyphicon glyphicon-plus",
@@ -8435,6 +9489,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "plus-sign",
     "tags": "",
     "class": "glyphicon glyphicon-plus-sign",
@@ -8443,6 +9498,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "print",
     "tags": "printer, computer",
     "class": "glyphicon glyphicon-print",
@@ -8451,6 +9507,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "pushpin",
     "tags": "",
     "class": "glyphicon glyphicon-pushpin",
@@ -8459,6 +9516,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "qrcode",
     "tags": "",
     "class": "glyphicon glyphicon-qrcode",
@@ -8467,6 +9525,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "queen",
     "tags": "chess, game",
     "class": "glyphicon glyphicon-queen",
@@ -8475,6 +9534,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "question-sign",
     "tags": "",
     "class": "glyphicon glyphicon-question-sign",
@@ -8483,6 +9543,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "random",
     "tags": "video player",
     "class": "glyphicon glyphicon-random",
@@ -8491,6 +9552,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "record",
     "tags": "video player",
     "class": "glyphicon glyphicon-record",
@@ -8499,6 +9561,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "refresh",
     "tags": "reload",
     "class": "glyphicon glyphicon-refresh",
@@ -8507,6 +9570,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "registration-mark",
     "tags": "",
     "class": "glyphicon glyphicon-registration-mark",
@@ -8515,6 +9579,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "remove",
     "tags": "",
     "class": "glyphicon glyphicon-remove",
@@ -8523,6 +9588,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "remove-circle",
     "tags": "",
     "class": "glyphicon glyphicon-remove-circle",
@@ -8531,6 +9597,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "remove-sign",
     "tags": "",
     "class": "glyphicon glyphicon-remove-sign",
@@ -8539,6 +9606,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "repeat",
     "tags": "text editor",
     "class": "glyphicon glyphicon-repeat",
@@ -8547,6 +9615,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "resize-full",
     "tags": "video player",
     "class": "glyphicon glyphicon-resize-full",
@@ -8555,6 +9624,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "resize-horizontal",
     "tags": "",
     "class": "glyphicon glyphicon-resize-horizontal",
@@ -8563,6 +9633,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "resize-small",
     "tags": "video player",
     "class": "glyphicon glyphicon-resize-small",
@@ -8571,6 +9642,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "resize-vertical",
     "tags": "",
     "class": "glyphicon glyphicon-resize-vertical",
@@ -8579,6 +9651,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "retweet",
     "tags": "",
     "class": "glyphicon glyphicon-retweet",
@@ -8587,6 +9660,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "road",
     "tags": "",
     "class": "glyphicon glyphicon-road",
@@ -8595,6 +9669,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "ruble",
     "tags": "currency, money",
     "class": "glyphicon glyphicon-ruble",
@@ -8603,6 +9678,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "save",
     "tags": "text editor",
     "class": "glyphicon glyphicon-save",
@@ -8611,6 +9687,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "save-file",
     "tags": "",
     "class": "glyphicon glyphicon-save-file",
@@ -8619,6 +9696,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "saved",
     "tags": "text editor",
     "class": "glyphicon glyphicon-saved",
@@ -8627,6 +9705,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "scale",
     "tags": "measure, weight",
     "class": "glyphicon glyphicon-scale",
@@ -8635,6 +9714,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "scissors",
     "tags": "cut",
     "class": "glyphicon glyphicon-scissors",
@@ -8643,6 +9723,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "screenshot",
     "tags": "",
     "class": "glyphicon glyphicon-screenshot",
@@ -8651,6 +9732,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "sd-video",
     "tags": "video player",
     "class": "glyphicon glyphicon-sd-video",
@@ -8659,6 +9741,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "search",
     "tags": "find, magnifying glass",
     "class": "glyphicon glyphicon-search",
@@ -8667,6 +9750,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "send",
     "tags": "email, paper airplane",
     "class": "glyphicon glyphicon-send",
@@ -8675,6 +9759,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "share",
     "tags": "",
     "class": "glyphicon glyphicon-share",
@@ -8683,6 +9768,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "share-alt",
     "tags": "",
     "class": "glyphicon glyphicon-share-alt",
@@ -8691,6 +9777,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "shopping-cart",
     "tags": "",
     "class": "glyphicon glyphicon-shopping-cart",
@@ -8699,6 +9786,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "signal",
     "tags": "bars, graph",
     "class": "glyphicon glyphicon-signal",
@@ -8707,6 +9795,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "sort",
     "tags": "text editor",
     "class": "glyphicon glyphicon-sort",
@@ -8715,6 +9804,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "sort-by-alphabet",
     "tags": "text editor",
     "class": "glyphicon glyphicon-sort-by-alphabet",
@@ -8723,6 +9813,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "sort-by-alphabet-alt",
     "tags": "text editor",
     "class": "glyphicon glyphicon-sort-by-alphabet-alt",
@@ -8731,6 +9822,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "sort-by-attributes",
     "tags": "text editor",
     "class": "glyphicon glyphicon-sort-by-attributes",
@@ -8739,6 +9831,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "sort-by-attributes-alt",
     "tags": "text editor",
     "class": "glyphicon glyphicon-sort-by-attributes-alt",
@@ -8747,6 +9840,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "sort-by-order",
     "tags": "text editor",
     "class": "glyphicon glyphicon-sort-by-order",
@@ -8755,6 +9849,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "sort-by-order-alt",
     "tags": "text editor",
     "class": "glyphicon glyphicon-sort-by-order-alt",
@@ -8763,6 +9858,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "sound-5-1",
     "tags": "video player, audio",
     "class": "glyphicon glyphicon-sound-5-1",
@@ -8771,6 +9867,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "sound-6-1",
     "tags": "video player, audio",
     "class": "glyphicon glyphicon-sound-6-1",
@@ -8779,6 +9876,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "sound-7-1",
     "tags": "video player, audio",
     "class": "glyphicon glyphicon-sound-7-1",
@@ -8787,6 +9885,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "sound-dolby",
     "tags": "video player, audio",
     "class": "glyphicon glyphicon-sound-dolby",
@@ -8795,6 +9894,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "sound-stereo",
     "tags": "video player, audio",
     "class": "glyphicon glyphicon-sound-stereo",
@@ -8803,6 +9903,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "star",
     "tags": "favorite, ratings, rate",
     "class": "glyphicon glyphicon-star",
@@ -8811,6 +9912,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "star-empty",
     "tags": "favorite, ratings, rate",
     "class": "glyphicon glyphicon-star-empty",
@@ -8819,6 +9921,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "stats",
     "tags": "graph",
     "class": "glyphicon glyphicon-stats",
@@ -8827,6 +9930,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "step-backward",
     "tags": "",
     "class": "glyphicon glyphicon-step-backward",
@@ -8835,6 +9939,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "step-forward",
     "tags": "",
     "class": "glyphicon glyphicon-step-forward",
@@ -8843,6 +9948,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "stop",
     "tags": "video player, square",
     "class": "glyphicon glyphicon-stop",
@@ -8851,6 +9957,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "subscript",
     "tags": "text editor",
     "class": "glyphicon glyphicon-subscript",
@@ -8859,6 +9966,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "subtitles",
     "tags": "video player",
     "class": "glyphicon glyphicon-subtitles",
@@ -8867,6 +9975,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "sunglasses",
     "tags": "",
     "class": "glyphicon glyphicon-sunglasses",
@@ -8875,6 +9984,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "superscript",
     "tags": "text editor",
     "class": "glyphicon glyphicon-superscript",
@@ -8883,6 +9993,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "tag",
     "tags": "pricetag",
     "class": "glyphicon glyphicon-tag",
@@ -8891,6 +10002,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "tags",
     "tags": "pricetags",
     "class": "glyphicon glyphicon-tags",
@@ -8899,6 +10011,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "tasks",
     "tags": "",
     "class": "glyphicon glyphicon-tasks",
@@ -8907,6 +10020,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "tent",
     "tags": "camping",
     "class": "glyphicon glyphicon-tent",
@@ -8915,6 +10029,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "text-background",
     "tags": "text editor",
     "class": "glyphicon glyphicon-text-background",
@@ -8923,6 +10038,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "text-color",
     "tags": "text editor",
     "class": "glyphicon glyphicon-text-color",
@@ -8931,6 +10047,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "text-height",
     "tags": "text editor",
     "class": "glyphicon glyphicon-text-height",
@@ -8939,6 +10056,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "text-size",
     "tags": "text editor",
     "class": "glyphicon glyphicon-text-size",
@@ -8947,6 +10065,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "text-width",
     "tags": "text editor",
     "class": "glyphicon glyphicon-text-width",
@@ -8955,6 +10074,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "th",
     "tags": "text editor",
     "class": "glyphicon glyphicon-th",
@@ -8963,6 +10083,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "th-large",
     "tags": "text editor",
     "class": "glyphicon glyphicon-th-large",
@@ -8971,6 +10092,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "th-list",
     "tags": "text editor",
     "class": "glyphicon glyphicon-th-list",
@@ -8979,6 +10101,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "thumbs-down",
     "tags": "unlike, ratings, rate",
     "class": "glyphicon glyphicon-thumbs-down",
@@ -8987,6 +10110,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "thumbs-up",
     "tags": "like, ratings, rate",
     "class": "glyphicon glyphicon-thumbs-up",
@@ -8995,6 +10119,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "time",
     "tags": "clock",
     "class": "glyphicon glyphicon-time",
@@ -9003,6 +10128,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "tint",
     "tags": "droplet",
     "class": "glyphicon glyphicon-tint",
@@ -9011,6 +10137,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "tower",
     "tags": "chess, game, rook",
     "class": "glyphicon glyphicon-tower",
@@ -9019,6 +10146,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "transfer",
     "tags": "exchange, arrows",
     "class": "glyphicon glyphicon-transfer",
@@ -9027,6 +10155,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "trash",
     "tags": "delete",
     "class": "glyphicon glyphicon-trash",
@@ -9035,6 +10164,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "tree-conifer",
     "tags": "plant",
     "class": "glyphicon glyphicon-tree-conifer",
@@ -9043,6 +10173,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "tree-deciduous",
     "tags": "plant",
     "class": "glyphicon glyphicon-tree-deciduous",
@@ -9051,6 +10182,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "triangle-bottom",
     "tags": "",
     "class": "glyphicon glyphicon-triangle-bottom",
@@ -9059,6 +10191,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "triangle-left",
     "tags": "",
     "class": "glyphicon glyphicon-triangle-left",
@@ -9067,6 +10200,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "triangle-right",
     "tags": "",
     "class": "glyphicon glyphicon-triangle-right",
@@ -9075,6 +10209,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "triangle-top",
     "tags": "",
     "class": "glyphicon glyphicon-triangle-top",
@@ -9083,6 +10218,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "unchecked",
     "tags": "form control",
     "class": "glyphicon glyphicon-unchecked",
@@ -9091,6 +10227,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "upload",
     "tags": "",
     "class": "glyphicon glyphicon-upload",
@@ -9099,6 +10236,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "usd",
     "tags": "currency, money, dollar",
     "class": "glyphicon glyphicon-usd",
@@ -9107,6 +10245,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "user",
     "tags": "person",
     "class": "glyphicon glyphicon-user",
@@ -9115,6 +10254,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "volume-down",
     "tags": "audio, sound",
     "class": "glyphicon glyphicon-volume-down",
@@ -9123,6 +10263,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "volume-off",
     "tags": "audio, sound",
     "class": "glyphicon glyphicon-volume-off",
@@ -9131,6 +10272,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "volume-up",
     "tags": "audio, sound",
     "class": "glyphicon glyphicon-volume-up",
@@ -9139,6 +10281,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "warning-sign",
     "tags": "caution, danger",
     "class": "glyphicon glyphicon-warning-sign",
@@ -9147,6 +10290,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "wrench",
     "tags": "tool, settings",
     "class": "glyphicon glyphicon-wrench",
@@ -9155,6 +10299,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "yen",
     "tags": "currency, money",
     "class": "glyphicon glyphicon-yen",
@@ -9163,6 +10308,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "zoom-in",
     "tags": "magnifying glass",
     "class": "glyphicon glyphicon-zoom-in",
@@ -9171,6 +10317,7 @@
   },
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "zoom-out",
     "tags": "magnifying glass",
     "class": "glyphicon glyphicon-zoom-out",
@@ -9180,6 +10327,7 @@
 
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "alert",
     "tags": "danger, exclamation point, warning",
     "class": "ionicons ion-alert",
@@ -9188,6 +10336,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "alert-circled",
     "tags": "danger, exclamation point, warning",
     "class": "ionicons ion-alert-circled",
@@ -9196,6 +10345,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "android-add",
     "tags": "plus",
     "class": "ionicons ion-android-add",
@@ -9204,6 +10354,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "android-add-circle",
     "tags": "plus",
     "class": "ionicons ion-android-add-circle",
@@ -9212,6 +10363,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "android-alarm-clock",
     "tags": "time",
     "class": "ionicons ion-android-alarm-clock",
@@ -9220,6 +10372,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "android-alert",
     "tags": "danger, exclamation point, warning",
     "class": "ionicons ion-android-alert",
@@ -9228,6 +10381,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "android-apps",
     "tags": "grid",
     "class": "ionicons ion-android-apps",
@@ -9236,6 +10390,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "android-archive",
     "tags": "save",
     "class": "ionicons ion-android-archive",
@@ -9244,6 +10399,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "android-arrow-back",
     "tags": "directional",
     "class": "ionicons ion-android-arrow-back",
@@ -9252,6 +10408,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "android-arrow-down",
     "tags": "directional",
     "class": "ionicons ion-android-arrow-down",
@@ -9260,6 +10417,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "android-arrow-dropdown",
     "tags": "caret",
     "class": "ionicons ion-android-arrow-dropdown",
@@ -9268,6 +10426,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "android-arrow-dropdown-circle",
     "tags": "caret",
     "class": "ionicons ion-android-arrow-dropdown-circle",
@@ -9276,6 +10435,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "android-arrow-dropleft",
     "tags": "caret",
     "class": "ionicons ion-android-arrow-dropleft",
@@ -9284,6 +10444,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "android-arrow-dropleft-circle",
     "tags": "caret",
     "class": "ionicons ion-android-arrow-dropleft-circle",
@@ -9292,6 +10453,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "android-arrow-dropright",
     "tags": "caret",
     "class": "ionicons ion-android-arrow-dropright",
@@ -9300,6 +10462,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "android-arrow-dropright-circle",
     "tags": "caret",
     "class": "ionicons ion-android-arrow-dropright-circle",
@@ -9308,6 +10471,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "android-arrow-dropup",
     "tags": "caret",
     "class": "ionicons ion-android-arrow-dropup",
@@ -9316,6 +10480,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "android-arrow-dropup-circle",
     "tags": "caret",
     "class": "ionicons ion-android-arrow-dropup-circle",
@@ -9324,6 +10489,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "android-arrow-forward",
     "tags": "directional",
     "class": "ionicons ion-android-arrow-forward",
@@ -9332,6 +10498,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "android-arrow-up",
     "tags": "directional",
     "class": "ionicons ion-android-arrow-up",
@@ -9340,6 +10507,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "android-attach",
     "tags": "paperclip",
     "class": "ionicons ion-android-attach",
@@ -9348,6 +10516,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "android-bar",
     "tags": "drink, glass, martini",
     "class": "ionicons ion-android-bar",
@@ -9356,6 +10525,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "android-bicycle",
     "tags": "transportation",
     "class": "ionicons ion-android-bicycle",
@@ -9364,6 +10534,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "android-boat",
     "tags": "ship, transportation",
     "class": "ionicons ion-android-boat",
@@ -9372,6 +10543,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "android-bookmark",
     "tags": "",
     "class": "ionicons ion-android-bookmark",
@@ -9380,6 +10552,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "android-bulb",
     "tags": "light",
     "class": "ionicons ion-android-bulb",
@@ -9388,6 +10561,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "android-bus",
     "tags": "transportation",
     "class": "ionicons ion-android-bus",
@@ -9396,6 +10570,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "android-calendar",
     "tags": "date",
     "class": "ionicons ion-android-calendar",
@@ -9404,6 +10579,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "android-call",
     "tags": "phone",
     "class": "ionicons ion-android-call",
@@ -9412,6 +10588,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "android-camera",
     "tags": "",
     "class": "ionicons ion-android-camera",
@@ -9420,6 +10597,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "android-cancel",
     "tags": "",
     "class": "ionicons ion-android-cancel",
@@ -9428,6 +10606,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "android-car",
     "tags": "automobile, transportation",
     "class": "ionicons ion-android-car",
@@ -9436,6 +10615,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "android-cart",
     "tags": "",
     "class": "ionicons ion-android-cart",
@@ -9444,6 +10624,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "android-chat",
     "tags": "quotes, speech bubble",
     "class": "ionicons ion-android-chat",
@@ -9452,6 +10633,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "android-checkbox",
     "tags": "",
     "class": "ionicons ion-android-checkbox",
@@ -9460,6 +10642,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "android-checkbox-blank",
     "tags": "",
     "class": "ionicons ion-android-checkbox-blank",
@@ -9468,6 +10651,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "android-checkbox-outline",
     "tags": "",
     "class": "ionicons ion-android-checkbox-outline",
@@ -9476,6 +10660,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "android-checkbox-outline-blank",
     "tags": "",
     "class": "ionicons ion-android-checkbox-outline-blank",
@@ -9484,6 +10669,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "android-checkmark-circle",
     "tags": "",
     "class": "ionicons ion-android-checkmark-circle",
@@ -9492,6 +10678,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "android-clipboard",
     "tags": "",
     "class": "ionicons ion-android-clipboard",
@@ -9500,6 +10687,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "android-close",
     "tags": "times",
     "class": "ionicons ion-android-close",
@@ -9508,6 +10696,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "android-cloud",
     "tags": "weather",
     "class": "ionicons ion-android-cloud",
@@ -9516,6 +10705,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "android-cloud-circle",
     "tags": "weather",
     "class": "ionicons ion-android-cloud-circle",
@@ -9524,6 +10714,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "android-cloud-done",
     "tags": "weather",
     "class": "ionicons ion-android-cloud-done",
@@ -9532,6 +10723,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "android-cloud-outline",
     "tags": "weather",
     "class": "ionicons ion-android-cloud-outline",
@@ -9540,6 +10732,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "android-color-palette",
     "tags": "art, paint",
     "class": "ionicons ion-android-color-palette",
@@ -9548,6 +10741,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "android-compass",
     "tags": "directions, navigation",
     "class": "ionicons ion-android-compass",
@@ -9556,6 +10750,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "android-contact",
     "tags": "person, user",
     "class": "ionicons ion-android-contact",
@@ -9564,6 +10759,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "android-contacts",
     "tags": "people, users",
     "class": "ionicons ion-android-contacts",
@@ -9572,6 +10768,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "android-contract",
     "tags": "resize, compress, shrink",
     "class": "ionicons ion-android-contract",
@@ -9580,6 +10777,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "android-create",
     "tags": "pencil, write",
     "class": "ionicons ion-android-create",
@@ -9588,6 +10786,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "android-delete",
     "tags": "trashcan",
     "class": "ionicons ion-android-delete",
@@ -9596,6 +10795,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "android-desktop",
     "tags": "monitor, computer",
     "class": "ionicons ion-android-desktop",
@@ -9604,6 +10804,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "android-document",
     "tags": "file",
     "class": "ionicons ion-android-document",
@@ -9612,6 +10813,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "android-done",
     "tags": "checkmark",
     "class": "ionicons ion-android-done",
@@ -9620,6 +10822,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "android-done-all",
     "tags": "checkmark",
     "class": "ionicons ion-android-done-all",
@@ -9628,6 +10831,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "android-download",
     "tags": "cloud",
     "class": "ionicons ion-android-download",
@@ -9636,6 +10840,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "android-drafts",
     "tags": "envelope",
     "class": "ionicons ion-android-drafts",
@@ -9644,6 +10849,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "android-exit",
     "tags": "",
     "class": "ionicons ion-android-exit",
@@ -9652,6 +10858,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "android-expand",
     "tags": "resize",
     "class": "ionicons ion-android-expand",
@@ -9660,6 +10867,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "android-favorite",
     "tags": "heart, like",
     "class": "ionicons ion-android-favorite",
@@ -9668,6 +10876,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "android-favorite-outline",
     "tags": "heart, like",
     "class": "ionicons ion-android-favorite-outline",
@@ -9676,6 +10885,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "android-film",
     "tags": "movie",
     "class": "ionicons ion-android-film",
@@ -9684,6 +10894,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "android-folder",
     "tags": "",
     "class": "ionicons ion-android-folder",
@@ -9692,6 +10903,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "android-folder-open",
     "tags": "",
     "class": "ionicons ion-android-folder-open",
@@ -9700,6 +10912,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "android-funnel",
     "tags": "filter",
     "class": "ionicons ion-android-funnel",
@@ -9708,6 +10921,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "android-globe",
     "tags": "earth, world",
     "class": "ionicons ion-android-globe",
@@ -9716,6 +10930,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "android-hand",
     "tags": "",
     "class": "ionicons ion-android-hand",
@@ -9724,6 +10939,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "android-hangout",
     "tags": "chat bubble",
     "class": "ionicons ion-android-hangout",
@@ -9732,6 +10948,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "android-happy",
     "tags": "smiley face",
     "class": "ionicons ion-android-happy",
@@ -9740,6 +10957,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "android-home",
     "tags": "house",
     "class": "ionicons ion-android-home",
@@ -9748,6 +10966,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "android-image",
     "tags": "email",
     "class": "ionicons ion-android-image",
@@ -9756,6 +10975,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "android-laptop",
     "tags": "computer",
     "class": "ionicons ion-android-laptop",
@@ -9764,6 +10984,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "android-list",
     "tags": "",
     "class": "ionicons ion-android-list",
@@ -9772,6 +10993,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "android-locate",
     "tags": "target",
     "class": "ionicons ion-android-locate",
@@ -9780,6 +11002,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "android-lock",
     "tags": "",
     "class": "ionicons ion-android-lock",
@@ -9788,6 +11011,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "android-mail",
     "tags": "envelope",
     "class": "ionicons ion-android-mail",
@@ -9796,6 +11020,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "android-map",
     "tags": "",
     "class": "ionicons ion-android-map",
@@ -9804,6 +11029,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "android-menu",
     "tags": "bars, more, hamburger menu",
     "class": "ionicons ion-android-menu",
@@ -9812,6 +11038,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "android-microphone",
     "tags": "audio",
     "class": "ionicons ion-android-microphone",
@@ -9820,6 +11047,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "android-microphone-off",
     "tags": "audio, mute",
     "class": "ionicons ion-android-microphone-off",
@@ -9828,6 +11056,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "android-more-horizontal",
     "tags": "",
     "class": "ionicons ion-android-more-horizontal",
@@ -9836,6 +11065,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "android-more-vertical",
     "tags": "",
     "class": "ionicons ion-android-more-vertical",
@@ -9844,6 +11074,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "android-navigate",
     "tags": "arrow",
     "class": "ionicons ion-android-navigate",
@@ -9852,6 +11083,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "android-notifications",
     "tags": "bell",
     "class": "ionicons ion-android-notifications",
@@ -9860,6 +11092,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "android-notifications-none",
     "tags": "bell",
     "class": "ionicons ion-android-notifications-none",
@@ -9868,6 +11101,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "android-notifications-off",
     "tags": "bell, mute",
     "class": "ionicons ion-android-notifications-off",
@@ -9876,6 +11110,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "android-open",
     "tags": "",
     "class": "ionicons ion-android-open",
@@ -9884,6 +11119,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "android-options",
     "tags": "levels, equalizer",
     "class": "ionicons ion-android-options",
@@ -9892,6 +11128,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "android-people",
     "tags": "users",
     "class": "ionicons ion-android-people",
@@ -9900,6 +11137,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "android-person",
     "tags": "user",
     "class": "ionicons ion-android-person",
@@ -9908,6 +11146,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "android-person-add",
     "tags": "user",
     "class": "ionicons ion-android-person-add",
@@ -9916,6 +11155,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "android-phone-landscape",
     "tags": "",
     "class": "ionicons ion-android-phone-landscape",
@@ -9924,6 +11164,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "android-phone-portrait",
     "tags": "",
     "class": "ionicons ion-android-phone-portrait",
@@ -9932,6 +11173,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "android-pin",
     "tags": "map marker",
     "class": "ionicons ion-android-pin",
@@ -9940,6 +11182,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "android-plane",
     "tags": "transportation, travel",
     "class": "ionicons ion-android-plane",
@@ -9948,6 +11191,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "android-playstore",
     "tags": "shopping",
     "class": "ionicons ion-android-playstore",
@@ -9956,6 +11200,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "android-print",
     "tags": "",
     "class": "ionicons ion-android-print",
@@ -9964,6 +11209,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "android-radio-button-on",
     "tags": "",
     "class": "ionicons ion-android-radio-button-on",
@@ -9972,6 +11218,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "android-radio-button-off",
     "tags": "",
     "class": "ionicons ion-android-radio-button-off",
@@ -9980,6 +11227,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "android-refresh",
     "tags": "reload",
     "class": "ionicons ion-android-refresh",
@@ -9988,6 +11236,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "android-remove",
     "tags": "minus",
     "class": "ionicons ion-android-remove",
@@ -9996,6 +11245,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "android-remove-circle",
     "tags": "minus",
     "class": "ionicons ion-android-remove-circle",
@@ -10004,6 +11254,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "android-restaurant",
     "tags": "cutlery, food, dining, spoon, knife",
     "class": "ionicons ion-android-restaurant",
@@ -10012,6 +11263,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "android-sad",
     "tags": "frown, face",
     "class": "ionicons ion-android-sad",
@@ -10020,6 +11272,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "android-search",
     "tags": "find, magnifying glass",
     "class": "ionicons ion-android-search",
@@ -10028,6 +11281,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "android-send",
     "tags": "paper airplane",
     "class": "ionicons ion-android-send",
@@ -10036,6 +11290,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "android-settings",
     "tags": "cog, gear",
     "class": "ionicons ion-android-settings",
@@ -10044,6 +11299,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "android-share",
     "tags": "arrow",
     "class": "ionicons ion-android-share",
@@ -10052,6 +11308,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "android-share-alt",
     "tags": "",
     "class": "ionicons ion-android-share-alt",
@@ -10060,6 +11317,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "android-star",
     "tags": "rating",
     "class": "ionicons ion-android-star",
@@ -10068,6 +11326,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "android-star-half",
     "tags": "rating",
     "class": "ionicons ion-android-star-half",
@@ -10076,6 +11335,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "android-star-outline",
     "tags": "rating",
     "class": "ionicons ion-android-star-outline",
@@ -10084,6 +11344,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "android-stopwatch",
     "tags": "timer",
     "class": "ionicons ion-android-stopwatch",
@@ -10092,6 +11353,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "android-subway",
     "tags": "transportation",
     "class": "ionicons ion-android-subway",
@@ -10100,6 +11362,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "android-sunny",
     "tags": "weather",
     "class": "ionicons ion-android-sunny",
@@ -10108,6 +11371,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "android-sync",
     "tags": "refresh, reload",
     "class": "ionicons ion-android-sync",
@@ -10116,6 +11380,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "android-textsms",
     "tags": "chat bubble",
     "class": "ionicons ion-android-textsms",
@@ -10124,6 +11389,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "android-time",
     "tags": "clock",
     "class": "ionicons ion-android-time",
@@ -10132,6 +11398,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "android-train",
     "tags": "transportation",
     "class": "ionicons ion-android-train",
@@ -10140,6 +11407,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "android-unlock",
     "tags": "",
     "class": "ionicons ion-android-unlock",
@@ -10148,6 +11416,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "android-upload",
     "tags": "cloud",
     "class": "ionicons ion-android-upload",
@@ -10156,6 +11425,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "android-volume-down",
     "tags": "audio",
     "class": "ionicons ion-android-volume-down",
@@ -10164,6 +11434,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "android-volume-mute",
     "tags": "audio",
     "class": "ionicons ion-android-volume-mute",
@@ -10172,6 +11443,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "android-volume-off",
     "tags": "audio",
     "class": "ionicons ion-android-volume-off",
@@ -10180,6 +11452,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "android-volume-up",
     "tags": "audio",
     "class": "ionicons ion-android-volume-up",
@@ -10188,6 +11461,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "android-walk",
     "tags": "person",
     "class": "ionicons ion-android-walk",
@@ -10196,6 +11470,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "android-warning",
     "tags": "alert, sign",
     "class": "ionicons ion-android-warning",
@@ -10204,6 +11479,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "android-watch",
     "tags": "",
     "class": "ionicons ion-android-watch",
@@ -10212,6 +11488,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "android-wifi",
     "tags": "",
     "class": "ionicons ion-android-wifi",
@@ -10220,6 +11497,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "aperture",
     "tags": "camera, photos",
     "class": "ionicons ion-aperture",
@@ -10228,6 +11506,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "archive",
     "tags": "email",
     "class": "ionicons ion-archive",
@@ -10236,6 +11515,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "arrow-down-a",
     "tags": "directional",
     "class": "ionicons ion-arrow-down-a",
@@ -10244,6 +11524,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "arrow-down-b",
     "tags": "directional, triangle, caret",
     "class": "ionicons ion-arrow-down-b",
@@ -10252,6 +11533,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "arrow-down-c",
     "tags": "directional",
     "class": "ionicons ion-arrow-down-c",
@@ -10260,6 +11542,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "arrow-expand",
     "tags": "resize",
     "class": "ionicons ion-arrow-expand",
@@ -10268,6 +11551,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "arrow-graph-down-left",
     "tags": "directional",
     "class": "ionicons ion-arrow-graph-down-left",
@@ -10276,6 +11560,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "arrow-graph-down-right",
     "tags": "directional",
     "class": "ionicons ion-arrow-graph-down-right",
@@ -10284,6 +11569,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "arrow-graph-up-left",
     "tags": "directional",
     "class": "ionicons ion-arrow-graph-up-left",
@@ -10292,6 +11578,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "arrow-graph-up-right",
     "tags": "directional",
     "class": "ionicons ion-arrow-graph-up-right",
@@ -10300,6 +11587,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "arrow-left-a",
     "tags": "directional",
     "class": "ionicons ion-arrow-left-a",
@@ -10308,6 +11596,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "arrow-left-b",
     "tags": "directional, triangle, caret",
     "class": "ionicons ion-arrow-left-b",
@@ -10316,6 +11605,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "arrow-left-c",
     "tags": "directional",
     "class": "ionicons ion-arrow-left-c",
@@ -10324,6 +11614,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "arrow-move",
     "tags": "",
     "class": "ionicons ion-arrow-move",
@@ -10332,6 +11623,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "arrow-resize",
     "tags": "",
     "class": "ionicons ion-arrow-resize",
@@ -10340,6 +11632,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "arrow-return-left",
     "tags": "directional",
     "class": "ionicons ion-arrow-return-left",
@@ -10348,6 +11641,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "arrow-return-right",
     "tags": "directional",
     "class": "ionicons ion-arrow-return-right",
@@ -10356,6 +11650,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "arrow-right-a",
     "tags": "directional",
     "class": "ionicons ion-arrow-right-a",
@@ -10364,6 +11659,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "arrow-right-b",
     "tags": "directional, triangle, caret",
     "class": "ionicons ion-arrow-right-b",
@@ -10372,6 +11668,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "arrow-right-c",
     "tags": "directional",
     "class": "ionicons ion-arrow-right-c",
@@ -10380,6 +11677,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "arrow-shrink",
     "tags": "resize, collapse",
     "class": "ionicons ion-arrow-shrink",
@@ -10388,6 +11686,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "arrow-swap",
     "tags": "exchange",
     "class": "ionicons ion-arrow-swap",
@@ -10396,6 +11695,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "arrow-up-a",
     "tags": "directional",
     "class": "ionicons ion-arrow-up-a",
@@ -10404,6 +11704,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "arrow-up-b",
     "tags": "directional, triangle, caret",
     "class": "ionicons ion-arrow-up-b",
@@ -10412,6 +11713,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "arrow-up-c",
     "tags": "directional",
     "class": "ionicons ion-arrow-up-c",
@@ -10420,6 +11722,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "asterisk",
     "tags": "",
     "class": "ionicons ion-asterisk",
@@ -10428,6 +11731,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "at",
     "tags": "email",
     "class": "ionicons ion-at",
@@ -10436,6 +11740,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "backspace",
     "tags": "delete",
     "class": "ionicons ion-backspace",
@@ -10444,6 +11749,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "backspace-outline",
     "tags": "delete",
     "class": "ionicons ion-backspace-outline",
@@ -10452,6 +11758,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "bag",
     "tags": "shopping",
     "class": "ionicons ion-bag",
@@ -10460,6 +11767,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "battery-charging",
     "tags": "power",
     "class": "ionicons ion-battery-charging",
@@ -10468,6 +11776,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "battery-empty",
     "tags": "power",
     "class": "ionicons ion-battery-empty",
@@ -10476,6 +11785,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "battery-full",
     "tags": "power",
     "class": "ionicons ion-battery-full",
@@ -10484,6 +11794,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "battery-half",
     "tags": "power",
     "class": "ionicons ion-battery-half",
@@ -10492,6 +11803,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "battery-low",
     "tags": "power",
     "class": "ionicons ion-battery-low",
@@ -10500,6 +11812,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "beaker",
     "tags": "flask, science, chemistry",
     "class": "ionicons ion-beaker",
@@ -10508,6 +11821,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "beer",
     "tags": "alcohol, drink, mug, stein",
     "class": "ionicons ion-beer",
@@ -10516,6 +11830,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "bluetooth",
     "tags": "",
     "class": "ionicons ion-bluetooth",
@@ -10524,6 +11839,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "bonfire",
     "tags": "campfire, flame",
     "class": "ionicons ion-bonfire",
@@ -10532,6 +11848,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "bookmark",
     "tags": "",
     "class": "ionicons ion-bookmark",
@@ -10540,6 +11857,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "bowtie",
     "tags": "",
     "class": "ionicons ion-bowtie",
@@ -10548,6 +11866,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "briefcase",
     "tags": "suitcase, business",
     "class": "ionicons ion-briefcase",
@@ -10556,6 +11875,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "bug",
     "tags": "beetle, insect",
     "class": "ionicons ion-bug",
@@ -10564,6 +11884,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "calculator",
     "tags": "",
     "class": "ionicons ion-calculator",
@@ -10572,6 +11893,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "calendar",
     "tags": "date",
     "class": "ionicons ion-calendar",
@@ -10580,6 +11902,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "camera",
     "tags": "photographs",
     "class": "ionicons ion-camera",
@@ -10588,6 +11911,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "card",
     "tags": "credit card, shopping, money",
     "class": "ionicons ion-card",
@@ -10596,6 +11920,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "cash",
     "tags": "dollar, money",
     "class": "ionicons ion-cash",
@@ -10604,6 +11929,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "chatbox",
     "tags": "speech bubble",
     "class": "ionicons ion-chatbox",
@@ -10612,6 +11938,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "chatbox-working",
     "tags": "speech bubble",
     "class": "ionicons ion-chatbox-working",
@@ -10620,6 +11947,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "chatboxes",
     "tags": "speech bubble",
     "class": "ionicons ion-chatboxes",
@@ -10628,6 +11956,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "chatbubble",
     "tags": "speech bubble",
     "class": "ionicons ion-chatbubble",
@@ -10636,6 +11965,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "chatbubble-working",
     "tags": "speech bubble",
     "class": "ionicons ion-chatbubble-working",
@@ -10644,6 +11974,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "chatbubbles",
     "tags": "speech bubble",
     "class": "ionicons ion-chatbubbles",
@@ -10652,6 +11983,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "checkmark",
     "tags": "",
     "class": "ionicons ion-checkmark",
@@ -10660,6 +11992,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "checkmark-circled",
     "tags": "",
     "class": "ionicons ion-checkmark-circled",
@@ -10668,6 +12001,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "checkmark-round",
     "tags": "",
     "class": "ionicons ion-checkmark-round",
@@ -10676,6 +12010,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "chevron-down",
     "tags": "angle, directional",
     "class": "ionicons ion-chevron-down",
@@ -10684,6 +12019,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "chevron-left",
     "tags": "angle, directional",
     "class": "ionicons ion-chevron-left",
@@ -10692,6 +12028,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "chevron-right",
     "tags": "angle, directional",
     "class": "ionicons ion-chevron-right",
@@ -10700,6 +12037,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "chevron-up",
     "tags": "angle, directional",
     "class": "ionicons ion-chevron-up",
@@ -10708,6 +12046,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "clipboard",
     "tags": "",
     "class": "ionicons ion-clipboard",
@@ -10716,6 +12055,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "closed-captioning",
     "tags": "",
     "class": "ionicons ion-closed-captioning",
@@ -10724,6 +12064,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "clock",
     "tags": "timer",
     "class": "ionicons ion-clock",
@@ -10732,6 +12073,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "close",
     "tags": "times",
     "class": "ionicons ion-close",
@@ -10740,6 +12082,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "close-circled",
     "tags": "times",
     "class": "ionicons ion-close-circled",
@@ -10748,6 +12091,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "close-round",
     "tags": "times",
     "class": "ionicons ion-close-round",
@@ -10756,6 +12100,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "closed-captioning",
     "tags": "cc",
     "class": "ionicons ion-closed-captioning",
@@ -10764,6 +12109,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "cloud",
     "tags": "weather",
     "class": "ionicons ion-cloud",
@@ -10772,6 +12118,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "code",
     "tags": "brackets, source",
     "class": "ionicons ion-code",
@@ -10780,6 +12127,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "code-download",
     "tags": "brackets, source",
     "class": "ionicons ion-code-download",
@@ -10788,6 +12136,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "code-working",
     "tags": "brackets, source",
     "class": "ionicons ion-code-working",
@@ -10796,6 +12145,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "coffee",
     "tags": "cup, drink, mug",
     "class": "ionicons ion-coffee",
@@ -10804,6 +12154,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "compass",
     "tags": "directions, navigation",
     "class": "ionicons ion-compass",
@@ -10812,6 +12163,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "compose",
     "tags": "email, write",
     "class": "ionicons ion-compose",
@@ -10820,6 +12172,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "connection-bars",
     "tags": "graph, signal",
     "class": "ionicons ion-connection-bars",
@@ -10828,6 +12181,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "contrast",
     "tags": "adjust",
     "class": "ionicons ion-contrast",
@@ -10836,6 +12190,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "crop",
     "tags": "",
     "class": "ionicons ion-crop",
@@ -10844,6 +12199,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "cube",
     "tags": "box",
     "class": "ionicons ion-cube",
@@ -10852,6 +12208,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "disc",
     "tags": "cd, music, vinyl",
     "class": "ionicons ion-disc",
@@ -10860,6 +12217,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "document",
     "tags": "text editor, file",
     "class": "ionicons ion-document",
@@ -10868,6 +12226,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "document-text",
     "tags": "text editor, file",
     "class": "ionicons ion-document-text",
@@ -10876,6 +12235,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "drag",
     "tags": "bars, hamburger menu, more, reorder",
     "class": "ionicons ion-drag",
@@ -10884,6 +12244,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "earth",
     "tags": "globe, planet, world",
     "class": "ionicons ion-earth",
@@ -10892,6 +12253,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "easel",
     "tags": "art, presentation",
     "class": "ionicons ion-easel",
@@ -10900,6 +12262,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "edit",
     "tags": "pencil, write",
     "class": "ionicons ion-edit",
@@ -10908,6 +12271,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "egg",
     "tags": "food",
     "class": "ionicons ion-egg",
@@ -10916,6 +12280,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "eject",
     "tags": "",
     "class": "ionicons ion-eject",
@@ -10924,6 +12289,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "email",
     "tags": "envelope",
     "class": "ionicons ion-email",
@@ -10932,6 +12298,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "email-unread",
     "tags": "envelope",
     "class": "ionicons ion-email-unread",
@@ -10940,6 +12307,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "erlenmeyer-flask",
     "tags": "beaker, chemistry, science",
     "class": "ionicons ion-erlenmeyer-flask",
@@ -10948,6 +12316,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "erlenmeyer-flask-bubbles",
     "tags": "beaker, chemistry, science",
     "class": "ionicons ion-erlenmeyer-flask-bubbles",
@@ -10956,6 +12325,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "eye",
     "tags": "show, view",
     "class": "ionicons ion-eye",
@@ -10964,6 +12334,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "eye-disabled",
     "tags": "hide, view",
     "class": "ionicons ion-eye-disabled",
@@ -10972,6 +12343,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "female",
     "tags": "gender, sex, venus",
     "class": "ionicons ion-female",
@@ -10980,6 +12352,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "filing",
     "tags": "archive",
     "class": "ionicons ion-filing",
@@ -10988,6 +12361,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "film-marker",
     "tags": "movie",
     "class": "ionicons ion-film-marker",
@@ -10996,6 +12370,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "fireball",
     "tags": "flame",
     "class": "ionicons ion-fireball",
@@ -11004,6 +12379,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "flag",
     "tags": "",
     "class": "ionicons ion-flag",
@@ -11012,6 +12388,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "flame",
     "tags": "fire",
     "class": "ionicons ion-flame",
@@ -11020,6 +12397,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "flash",
     "tags": "lightning bolt",
     "class": "ionicons ion-flash",
@@ -11028,6 +12406,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "flash-off",
     "tags": "lightning bolt",
     "class": "ionicons ion-flash-off",
@@ -11036,6 +12415,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "folder",
     "tags": "",
     "class": "ionicons ion-folder",
@@ -11044,6 +12424,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "fork",
     "tags": "cutlery, food, dining",
     "class": "ionicons ion-fork",
@@ -11052,6 +12433,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "fork-repo",
     "tags": "git",
     "class": "ionicons ion-fork-repo",
@@ -11060,6 +12442,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "forward",
     "tags": "arrow, email",
     "class": "ionicons ion-forward",
@@ -11068,6 +12451,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "funnel",
     "tags": "filter",
     "class": "ionicons ion-funnel",
@@ -11076,6 +12460,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "gear-a",
     "tags": "cog, settings",
     "class": "ionicons ion-gear-a",
@@ -11084,6 +12469,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "gear-b",
     "tags": "cog, settings",
     "class": "ionicons ion-gear-b",
@@ -11092,6 +12478,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "grid",
     "tags": "text editor",
     "class": "ionicons ion-grid",
@@ -11100,6 +12487,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "hammer",
     "tags": "tool",
     "class": "ionicons ion-hammer",
@@ -11108,6 +12496,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "happy",
     "tags": "smiley face",
     "class": "ionicons ion-happy",
@@ -11116,6 +12505,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "headphone",
     "tags": "audio, music",
     "class": "ionicons ion-headphone",
@@ -11124,6 +12514,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "heart",
     "tags": "like, rate, ratings",
     "class": "ionicons ion-heart",
@@ -11132,6 +12523,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "heart-broken",
     "tags": "",
     "class": "ionicons ion-heart-broken",
@@ -11140,6 +12532,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "help",
     "tags": "question mark",
     "class": "ionicons ion-help",
@@ -11148,6 +12541,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "help-buoy",
     "tags": "lifesaver, support",
     "class": "ionicons ion-help-buoy",
@@ -11156,6 +12550,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "help-circled",
     "tags": "question mark",
     "class": "ionicons ion-help-circled",
@@ -11164,6 +12559,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "home",
     "tags": "house",
     "class": "ionicons ion-home",
@@ -11172,6 +12568,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "icecream",
     "tags": "food, dessert, ice cream",
     "class": "ionicons ion-icecream",
@@ -11180,6 +12577,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "image",
     "tags": "picture, photograph",
     "class": "ionicons ion-image",
@@ -11188,6 +12586,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "images",
     "tags": "pictures, photographs",
     "class": "ionicons ion-images",
@@ -11196,6 +12595,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "information",
     "tags": "",
     "class": "ionicons ion-information",
@@ -11204,6 +12604,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "information-circled",
     "tags": "",
     "class": "ionicons ion-information-circled",
@@ -11212,6 +12613,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ionic",
     "tags": "atom, brand, logo, chemistry, science",
     "class": "ionicons ion-ionic",
@@ -11220,6 +12622,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-alarm",
     "tags": "clock, reminder, timer",
     "class": "ionicons ion-ios-alarm",
@@ -11228,6 +12631,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-alarm-outline",
     "tags": "clock, reminder, timer",
     "class": "ionicons ion-ios-alarm-outline",
@@ -11236,6 +12640,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-albums",
     "tags": "archive",
     "class": "ionicons ion-ios-albums",
@@ -11244,6 +12649,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-albums-outline",
     "tags": "archive",
     "class": "ionicons ion-ios-albums-outline",
@@ -11252,6 +12658,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-americanfootball",
     "tags": "sports",
     "class": "ionicons ion-ios-americanfootball",
@@ -11260,6 +12667,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-americanfootball-outline",
     "tags": "sports",
     "class": "ionicons ion-ios-americanfootball-outline",
@@ -11268,6 +12676,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-analytics",
     "tags": "signal",
     "class": "ionicons ion-ios-analytics",
@@ -11276,6 +12685,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-analytics-outline",
     "tags": "signal",
     "class": "ionicons ion-ios-analytics-outline",
@@ -11284,6 +12694,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-arrow-back",
     "tags": "directional",
     "class": "ionicons ion-ios-arrow-back",
@@ -11292,6 +12703,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-arrow-down",
     "tags": "chevron, directional",
     "class": "ionicons ion-ios-arrow-down",
@@ -11300,6 +12712,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-arrow-forward",
     "tags": "chevron, directional",
     "class": "ionicons ion-ios-arrow-forward",
@@ -11308,6 +12721,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-arrow-left",
     "tags": "chevron, directional",
     "class": "ionicons ion-ios-arrow-left",
@@ -11316,6 +12730,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-arrow-right",
     "tags": "chevron, directional",
     "class": "ionicons ion-ios-arrow-right",
@@ -11324,6 +12739,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-arrow-thin-down",
     "tags": "directional",
     "class": "ionicons ion-ios-arrow-thin-down",
@@ -11332,6 +12748,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-arrow-thin-left",
     "tags": "directional",
     "class": "ionicons ion-ios-arrow-thin-left",
@@ -11340,6 +12757,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-arrow-thin-right",
     "tags": "directional",
     "class": "ionicons ion-ios-arrow-thin-right",
@@ -11348,6 +12766,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-arrow-thin-up",
     "tags": "directional",
     "class": "ionicons ion-ios-arrow-thin-up",
@@ -11356,6 +12775,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-arrow-up",
     "tags": "chevron, directional",
     "class": "ionicons ion-ios-arrow-up",
@@ -11364,6 +12784,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-at",
     "tags": "email",
     "class": "ionicons ion-ios-at",
@@ -11372,6 +12793,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-at-outline",
     "tags": "email",
     "class": "ionicons ion-ios-at-outline",
@@ -11380,6 +12802,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-barcode",
     "tags": "",
     "class": "ionicons ion-ios-barcode",
@@ -11388,6 +12811,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-barcode-outline",
     "tags": "",
     "class": "ionicons ion-ios-barcode-outline",
@@ -11396,6 +12820,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-baseball",
     "tags": "sports",
     "class": "ionicons ion-ios-baseball",
@@ -11404,6 +12829,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-baseball-outline",
     "tags": "sports",
     "class": "ionicons ion-ios-baseball-outline",
@@ -11412,6 +12838,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-basketball",
     "tags": "sports",
     "class": "ionicons ion-ios-basketball",
@@ -11420,6 +12847,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-basketball-outline",
     "tags": "sports",
     "class": "ionicons ion-ios-basketball-outline",
@@ -11428,6 +12856,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-bell",
     "tags": "audio, sound",
     "class": "ionicons ion-ios-bell",
@@ -11436,6 +12865,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-bell-outline",
     "tags": "audio, sound",
     "class": "ionicons ion-ios-bell-outline",
@@ -11444,6 +12874,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-body",
     "tags": "person",
     "class": "ionicons ion-ios-body",
@@ -11452,6 +12883,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-body-outline",
     "tags": "person",
     "class": "ionicons ion-ios-body-outline",
@@ -11460,6 +12892,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-bolt",
     "tags": "lightning bolt, flash",
     "class": "ionicons ion-ios-bolt",
@@ -11468,6 +12901,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-bolt-outline",
     "tags": "lightning bolt, flash",
     "class": "ionicons ion-ios-bolt-outline",
@@ -11476,6 +12910,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-book",
     "tags": "read",
     "class": "ionicons ion-ios-book",
@@ -11484,6 +12919,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-book-outline",
     "tags": "read",
     "class": "ionicons ion-ios-book-outline",
@@ -11492,6 +12928,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-bookmarks",
     "tags": "",
     "class": "ionicons ion-ios-bookmarks",
@@ -11500,6 +12937,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-bookmarks-outline",
     "tags": "",
     "class": "ionicons ion-ios-bookmarks-outline",
@@ -11508,6 +12946,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-box",
     "tags": "archive",
     "class": "ionicons ion-ios-box",
@@ -11516,6 +12955,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-box-outline",
     "tags": "archive",
     "class": "ionicons ion-ios-box-outline",
@@ -11524,6 +12964,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-briefcase",
     "tags": "suitcase, business",
     "class": "ionicons ion-ios-briefcase",
@@ -11532,6 +12973,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-briefcase-outline",
     "tags": "suitcase, business",
     "class": "ionicons ion-ios-briefcase-outline",
@@ -11540,6 +12982,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-browsers",
     "tags": "boxes",
     "class": "ionicons ion-ios-browsers",
@@ -11548,6 +12991,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-browsers-outline",
     "tags": "boxes",
     "class": "ionicons ion-ios-browsers-outline",
@@ -11556,6 +13000,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-calculator",
     "tags": "",
     "class": "ionicons ion-ios-calculator",
@@ -11564,6 +13009,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-calculator-outline",
     "tags": "",
     "class": "ionicons ion-ios-calculator-outline",
@@ -11572,6 +13018,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-calendar",
     "tags": "date",
     "class": "ionicons ion-ios-calendar",
@@ -11580,6 +13027,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-calendar-outline",
     "tags": "date",
     "class": "ionicons ion-ios-calendar-outline",
@@ -11588,6 +13036,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-camera",
     "tags": "photographs",
     "class": "ionicons ion-ios-camera",
@@ -11596,6 +13045,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-camera-outline",
     "tags": "photographs",
     "class": "ionicons ion-ios-camera-outline",
@@ -11604,6 +13054,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-cart",
     "tags": "shopping",
     "class": "ionicons ion-ios-cart",
@@ -11612,6 +13063,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-cart-outline",
     "tags": "shopping",
     "class": "ionicons ion-ios-cart-outline",
@@ -11620,6 +13072,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-chatboxes",
     "tags": "speech bubble",
     "class": "ionicons ion-ios-chatboxes",
@@ -11628,6 +13081,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-chatboxes-outline",
     "tags": "speech bubble",
     "class": "ionicons ion-ios-chatboxes-outline",
@@ -11636,6 +13090,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-chatbubble",
     "tags": "speech bubble",
     "class": "ionicons ion-ios-chatbubble",
@@ -11644,6 +13099,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-chatbubble-outline",
     "tags": "speech bubble",
     "class": "ionicons ion-ios-chatbubble-outline",
@@ -11652,6 +13108,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-checkmark",
     "tags": "",
     "class": "ionicons ion-ios-checkmark",
@@ -11660,6 +13117,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-checkmark-empty",
     "tags": "",
     "class": "ionicons ion-ios-checkmark-empty",
@@ -11668,6 +13126,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-checkmark-outline",
     "tags": "",
     "class": "ionicons ion-ios-checkmark-outline",
@@ -11676,6 +13135,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-circle-filled",
     "tags": "",
     "class": "ionicons ion-ios-circle-filled",
@@ -11684,6 +13144,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-circle-outline",
     "tags": "",
     "class": "ionicons ion-ios-circle-outline",
@@ -11692,6 +13153,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-clock",
     "tags": "timer",
     "class": "ionicons ion-ios-clock",
@@ -11700,6 +13162,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-clock-outline",
     "tags": "timer",
     "class": "ionicons ion-ios-clock-outline",
@@ -11708,6 +13171,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-close",
     "tags": "times, remove",
     "class": "ionicons ion-ios-close",
@@ -11716,6 +13180,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-close-empty",
     "tags": "times, remove",
     "class": "ionicons ion-ios-close-empty",
@@ -11724,6 +13189,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-close-outline",
     "tags": "times, remove",
     "class": "ionicons ion-ios-close-outline",
@@ -11732,6 +13198,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-cloud",
     "tags": "weather",
     "class": "ionicons ion-ios-cloud",
@@ -11740,6 +13207,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-cloud-download",
     "tags": "",
     "class": "ionicons ion-ios-cloud-download",
@@ -11748,6 +13216,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-cloud-download-outline",
     "tags": "",
     "class": "ionicons ion-ios-cloud-download-outline",
@@ -11756,6 +13225,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-cloud-outline",
     "tags": "",
     "class": "ionicons ion-ios-cloud-outline",
@@ -11764,6 +13234,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-cloud-upload",
     "tags": "",
     "class": "ionicons ion-ios-cloud-upload",
@@ -11772,6 +13243,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-cloud-upload-outline",
     "tags": "",
     "class": "ionicons ion-ios-cloud-upload-outline",
@@ -11780,6 +13252,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-cloudy",
     "tags": "weather",
     "class": "ionicons ion-ios-cloudy",
@@ -11788,6 +13261,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-cloudy-night",
     "tags": "moon, weather",
     "class": "ionicons ion-ios-cloudy-night",
@@ -11796,6 +13270,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-cloudy-night-outline",
     "tags": "moon, weather",
     "class": "ionicons ion-ios-cloudy-night-outline",
@@ -11804,6 +13279,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-cloudy-outline",
     "tags": "weather",
     "class": "ionicons ion-ios-cloudy-outline",
@@ -11812,6 +13288,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-cog",
     "tags": "gear, settings",
     "class": "ionicons ion-ios-cog",
@@ -11820,6 +13297,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-cog-outline",
     "tags": "gears, settings",
     "class": "ionicons ion-ios-cog-outline",
@@ -11828,6 +13306,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-color-filter",
     "tags": "circles, venn diagram",
     "class": "ionicons ion-ios-color-filter",
@@ -11836,6 +13315,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-color-filter-outline",
     "tags": "circles, rings, venn diagram",
     "class": "ionicons ion-ios-color-filter-outline",
@@ -11844,6 +13324,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-color-wand",
     "tags": "magic",
     "class": "ionicons ion-ios-color-wand",
@@ -11852,6 +13333,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-color-wand-outline",
     "tags": "magic",
     "class": "ionicons ion-ios-color-wand-outline",
@@ -11860,6 +13342,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-compose",
     "tags": "email, pencil, write",
     "class": "ionicons ion-ios-compose",
@@ -11868,6 +13351,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-compose-outline",
     "tags": "email, pencil, write",
     "class": "ionicons ion-ios-compose-outline",
@@ -11876,6 +13360,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-contact",
     "tags": "head, user",
     "class": "ionicons ion-ios-contact",
@@ -11884,6 +13369,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-contact-outline",
     "tags": "head, user",
     "class": "ionicons ion-ios-contact-outline",
@@ -11892,6 +13378,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-copy",
     "tags": "clone, documents, duplicate, files",
     "class": "ionicons ion-ios-copy",
@@ -11900,6 +13387,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-copy-outline",
     "tags": "clone, documents, duplicate, files",
     "class": "ionicons ion-ios-copy-outline",
@@ -11908,6 +13396,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-crop",
     "tags": "",
     "class": "ionicons ion-ios-crop",
@@ -11916,6 +13405,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-crop-strong",
     "tags": "",
     "class": "ionicons ion-ios-crop-strong",
@@ -11924,6 +13414,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-download",
     "tags": "arrow",
     "class": "ionicons ion-ios-download",
@@ -11932,6 +13423,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-download-outline",
     "tags": "arrow",
     "class": "ionicons ion-ios-download-outline",
@@ -11940,6 +13432,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-drag",
     "tags": "bars, hamburger menu, more, reorder",
     "class": "ionicons ion-ios-drag",
@@ -11948,6 +13441,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-email",
     "tags": "envelope",
     "class": "ionicons ion-ios-email",
@@ -11956,6 +13450,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-email-outline",
     "tags": "envelope",
     "class": "ionicons ion-ios-email-outline",
@@ -11964,6 +13459,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-eye",
     "tags": "show, view",
     "class": "ionicons ion-ios-eye",
@@ -11972,6 +13468,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-eye-outline",
     "tags": "show, view",
     "class": "ionicons ion-ios-eye-outline",
@@ -11980,6 +13477,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-fastforward",
     "tags": "video player",
     "class": "ionicons ion-ios-fastforward",
@@ -11988,6 +13486,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-fastforward-outline",
     "tags": "video player",
     "class": "ionicons ion-ios-fastforward-outline",
@@ -11996,6 +13495,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-filing",
     "tags": "",
     "class": "ionicons ion-ios-filing",
@@ -12004,6 +13504,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-film",
     "tags": "movies",
     "class": "ionicons ion-ios-film",
@@ -12012,6 +13513,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-film-outline",
     "tags": "movies",
     "class": "ionicons ion-ios-film-outline",
@@ -12020,6 +13522,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-flag",
     "tags": "",
     "class": "ionicons ion-ios-flag",
@@ -12028,6 +13531,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-flag-outline",
     "tags": "",
     "class": "ionicons ion-ios-flag-outline",
@@ -12036,6 +13540,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-flame",
     "tags": "fire",
     "class": "ionicons ion-ios-flame",
@@ -12044,6 +13549,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-flame-outline",
     "tags": "fire",
     "class": "ionicons ion-ios-flame-outline",
@@ -12052,6 +13558,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-flask",
     "tags": "beaker, chemistry, science",
     "class": "ionicons ion-ios-flask",
@@ -12060,6 +13567,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-flask-outline",
     "tags": "beaker, chemistry, science",
     "class": "ionicons ion-ios-flask-outline",
@@ -12068,6 +13576,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-flower",
     "tags": "",
     "class": "ionicons ion-ios-flower",
@@ -12076,6 +13585,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-flower-outline",
     "tags": "",
     "class": "ionicons ion-ios-flower-outline",
@@ -12084,6 +13594,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-folder",
     "tags": "",
     "class": "ionicons ion-ios-folder",
@@ -12092,6 +13603,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-folder-outline",
     "tags": "",
     "class": "ionicons ion-ios-folder-outline",
@@ -12100,6 +13612,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-football",
     "tags": "sports, soccer",
     "class": "ionicons ion-ios-football",
@@ -12108,6 +13621,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-football-outline",
     "tags": "sports, soccer",
     "class": "ionicons ion-ios-football-outline",
@@ -12116,6 +13630,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-game-controller-a",
     "tags": "",
     "class": "ionicons ion-ios-game-controller-a",
@@ -12124,6 +13639,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-game-controller-a-outline",
     "tags": "",
     "class": "ionicons ion-ios-game-controller-a-outline",
@@ -12132,6 +13648,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-game-controller-b",
     "tags": "",
     "class": "ionicons ion-ios-game-controller-b",
@@ -12140,6 +13657,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-game-controller-b-outline",
     "tags": "",
     "class": "ionicons ion-ios-game-controller-b-outline",
@@ -12148,6 +13666,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-gear",
     "tags": "cog, settings",
     "class": "ionicons ion-ios-gear",
@@ -12156,6 +13675,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-gear-outline",
     "tags": "cogs, settings",
     "class": "ionicons ion-ios-gear-outline",
@@ -12164,6 +13684,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-glasses",
     "tags": "sunglasses",
     "class": "ionicons ion-ios-glasses",
@@ -12172,6 +13693,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-glasses-outline",
     "tags": "",
     "class": "ionicons ion-ios-glasses-outline",
@@ -12180,6 +13702,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-grid-view",
     "tags": "tic tac toe",
     "class": "ionicons ion-ios-grid-view",
@@ -12188,6 +13711,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-grid-view-outline",
     "tags": "tic tac toe",
     "class": "ionicons ion-ios-grid-view-outline",
@@ -12196,6 +13720,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-heart",
     "tags": "favorite, like, rate, ratings",
     "class": "ionicons ion-ios-heart",
@@ -12204,6 +13729,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-heart-outline",
     "tags": "favorite, like, rate, ratings",
     "class": "ionicons ion-ios-heart-outline",
@@ -12212,6 +13738,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-help",
     "tags": "question mark",
     "class": "ionicons ion-ios-help",
@@ -12220,6 +13747,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-help-empty",
     "tags": "question mark",
     "class": "ionicons ion-ios-help-empty",
@@ -12228,6 +13756,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-help-outline",
     "tags": "question mark",
     "class": "ionicons ion-ios-help-outline",
@@ -12236,6 +13765,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-home-outline",
     "tags": "house",
     "class": "ionicons ion-ios-home-outline",
@@ -12244,6 +13774,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-home",
     "tags": "house",
     "class": "ionicons ion-ios-home",
@@ -12252,6 +13783,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-infinite",
     "tags": "infinity, math symbol",
     "class": "ionicons ion-ios-infinite",
@@ -12260,6 +13792,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-infinite-outline",
     "tags": "infinity, math symbol",
     "class": "ionicons ion-ios-infinite-outline",
@@ -12268,6 +13801,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-information",
     "tags": "",
     "class": "ionicons ion-ios-information",
@@ -12276,6 +13810,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-information-empty",
     "tags": "",
     "class": "ionicons ion-ios-information-empty",
@@ -12284,6 +13819,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-information-outline",
     "tags": "",
     "class": "ionicons ion-ios-information-outline",
@@ -12292,6 +13828,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-ionic-outline",
     "tags": "atom, brand, logo, science, chemistry",
     "class": "ionicons ion-ios-ionic-outline",
@@ -12300,6 +13837,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-keypad",
     "tags": "grid",
     "class": "ionicons ion-ios-keypad",
@@ -12308,6 +13846,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-keypad-outline",
     "tags": "grid",
     "class": "ionicons ion-ios-keypad-outline",
@@ -12316,6 +13855,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-lightbulb",
     "tags": "",
     "class": "ionicons ion-ios-lightbulb",
@@ -12324,6 +13864,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-lightbulb-outline",
     "tags": "",
     "class": "ionicons ion-ios-lightbulb-outline",
@@ -12332,6 +13873,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-list",
     "tags": "",
     "class": "ionicons ion-ios-list",
@@ -12340,6 +13882,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-list-outline",
     "tags": "",
     "class": "ionicons ion-ios-list-outline",
@@ -12348,6 +13891,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-location",
     "tags": "map marker",
     "class": "ionicons ion-ios-location",
@@ -12356,6 +13900,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-location-outline",
     "tags": "map marker",
     "class": "ionicons ion-ios-location-outline",
@@ -12364,6 +13909,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-locked",
     "tags": "",
     "class": "ionicons ion-ios-locked",
@@ -12372,6 +13918,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-locked-outline",
     "tags": "",
     "class": "ionicons ion-ios-locked-outline",
@@ -12380,6 +13927,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-loop",
     "tags": "refresh, reload",
     "class": "ionicons ion-ios-loop",
@@ -12388,6 +13936,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-loop-strong",
     "tags": "refresh, reload",
     "class": "ionicons ion-ios-loop-strong",
@@ -12396,6 +13945,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-medical",
     "tags": "asterisk",
     "class": "ionicons ion-ios-medical",
@@ -12404,6 +13954,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-medical-outline",
     "tags": "asterisk",
     "class": "ionicons ion-ios-medical-outline",
@@ -12412,6 +13963,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-medkit",
     "tags": "medical, health, hospital",
     "class": "ionicons ion-ios-medkit",
@@ -12420,6 +13972,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-medkit-outline",
     "tags": "medical, health, hospital",
     "class": "ionicons ion-ios-medkit-outline",
@@ -12428,6 +13981,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-mic",
     "tags": "audio, sound",
     "class": "ionicons ion-ios-mic",
@@ -12436,6 +13990,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-mic-off",
     "tags": "audio, sound, mute",
     "class": "ionicons ion-ios-mic-off",
@@ -12444,6 +13999,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-mic-outline",
     "tags": "audio, sound",
     "class": "ionicons ion-ios-mic-outline",
@@ -12452,6 +14008,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-minus",
     "tags": "",
     "class": "ionicons ion-ios-minus",
@@ -12460,6 +14017,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-minus-empty",
     "tags": "",
     "class": "ionicons ion-ios-minus-empty",
@@ -12468,6 +14026,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-minus-outline",
     "tags": "",
     "class": "ionicons ion-ios-minus-outline",
@@ -12476,6 +14035,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-monitor",
     "tags": "computer, display",
     "class": "ionicons ion-ios-monitor",
@@ -12484,6 +14044,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-monitor-outline",
     "tags": "computer, display",
     "class": "ionicons ion-ios-monitor-outline",
@@ -12492,6 +14053,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-moon",
     "tags": "crescent, night",
     "class": "ionicons ion-ios-moon",
@@ -12500,6 +14062,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-moon-outline",
     "tags": "crescent, night",
     "class": "ionicons ion-ios-moon-outline",
@@ -12508,6 +14071,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-more",
     "tags": "dots, menu",
     "class": "ionicons ion-ios-more",
@@ -12516,6 +14080,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-more-outline",
     "tags": "dots, menu",
     "class": "ionicons ion-ios-more-outline",
@@ -12524,6 +14089,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-musical-note",
     "tags": "song",
     "class": "ionicons ion-ios-musical-note",
@@ -12532,6 +14098,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-musical-notes",
     "tags": "song",
     "class": "ionicons ion-ios-musical-notes",
@@ -12540,6 +14107,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-navigate",
     "tags": "compass, directions, location",
     "class": "ionicons ion-ios-navigate",
@@ -12548,6 +14116,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-navigate-outline",
     "tags": "compass, directions, location",
     "class": "ionicons ion-ios-navigate-outline",
@@ -12556,6 +14125,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-nutrition",
     "tags": "food, carrot",
     "class": "ionicons ion-ios-nutrition",
@@ -12564,6 +14134,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-nutrition-outline",
     "tags": "food, carrot",
     "class": "ionicons ion-ios-nutrition-outline",
@@ -12572,6 +14143,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-paper",
     "tags": "newspaper",
     "class": "ionicons ion-ios-paper",
@@ -12580,6 +14152,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-paper-outline",
     "tags": "newspaper",
     "class": "ionicons ion-ios-paper-outline",
@@ -12588,6 +14161,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-paperplane",
     "tags": "airplane",
     "class": "ionicons ion-ios-paperplane",
@@ -12596,6 +14170,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-paperplane-outline",
     "tags": "airplane",
     "class": "ionicons ion-ios-paperplane-outline",
@@ -12604,6 +14179,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-partlysunny",
     "tags": "weather",
     "class": "ionicons ion-ios-partlysunny",
@@ -12612,6 +14188,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-partlysunny-outline",
     "tags": "weather",
     "class": "ionicons ion-ios-partlysunny-outline",
@@ -12620,6 +14197,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-pause",
     "tags": "video player",
     "class": "ionicons ion-ios-pause",
@@ -12628,6 +14206,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-pause-outline",
     "tags": "video player",
     "class": "ionicons ion-ios-pause-outline",
@@ -12636,6 +14215,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-paw",
     "tags": "animal, pet",
     "class": "ionicons ion-ios-paw",
@@ -12644,6 +14224,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-paw-outline",
     "tags": "animal, pet",
     "class": "ionicons ion-ios-paw-outline",
@@ -12652,6 +14233,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-people",
     "tags": "users",
     "class": "ionicons ion-ios-people",
@@ -12660,6 +14242,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-people-outline",
     "tags": "users",
     "class": "ionicons ion-ios-people-outline",
@@ -12668,6 +14251,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-person",
     "tags": "user, head, profile",
     "class": "ionicons ion-ios-person",
@@ -12676,6 +14260,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-person-outline",
     "tags": "user, head, profile",
     "class": "ionicons ion-ios-person-outline",
@@ -12684,6 +14269,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-personadd",
     "tags": "user, head, profile",
     "class": "ionicons ion-ios-personadd",
@@ -12692,6 +14278,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-personadd-outline",
     "tags": "user, head, profile",
     "class": "ionicons ion-ios-personadd-outline",
@@ -12700,6 +14287,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-photos",
     "tags": "boxes, squares",
     "class": "ionicons ion-ios-photos",
@@ -12708,6 +14296,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-photos-outline",
     "tags": "boxes, squares",
     "class": "ionicons ion-ios-photos-outline",
@@ -12716,6 +14305,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-pie",
     "tags": "chart, graph",
     "class": "ionicons ion-ios-pie",
@@ -12724,6 +14314,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-pie-outline",
     "tags": "chart, graph",
     "class": "ionicons ion-ios-pie-outline",
@@ -12732,6 +14323,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-pint",
     "tags": "beer, drink, glass, alcohol",
     "class": "ionicons ion-ios-pint",
@@ -12740,6 +14332,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-pint-outline",
     "tags": "beer, drink, glass, alcohol",
     "class": "ionicons ion-ios-pint-outline",
@@ -12748,6 +14341,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-play",
     "tags": "video player, triangle",
     "class": "ionicons ion-ios-play",
@@ -12756,6 +14350,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-play-outline",
     "tags": "video player, triangle",
     "class": "ionicons ion-ios-play-outline",
@@ -12764,6 +14359,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-plus",
     "tags": "add",
     "class": "ionicons ion-ios-plus",
@@ -12772,6 +14368,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-plus-empty",
     "tags": "add",
     "class": "ionicons ion-ios-plus-empty",
@@ -12780,6 +14377,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-plus-outline",
     "tags": "add",
     "class": "ionicons ion-ios-plus-outline",
@@ -12788,6 +14386,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-pricetag",
     "tags": "shopping",
     "class": "ionicons ion-ios-pricetag",
@@ -12796,6 +14395,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-pricetag-outline",
     "tags": "shopping",
     "class": "ionicons ion-ios-pricetag-outline",
@@ -12804,6 +14404,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-pricetags",
     "tags": "shopping",
     "class": "ionicons ion-ios-pricetags",
@@ -12812,6 +14413,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-pricetags-outline",
     "tags": "shopping",
     "class": "ionicons ion-ios-pricetags-outline",
@@ -12820,6 +14422,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-printer",
     "tags": "computer",
     "class": "ionicons ion-ios-printer",
@@ -12828,6 +14431,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-printer-outline",
     "tags": "computer",
     "class": "ionicons ion-ios-printer-outline",
@@ -12836,6 +14440,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-pulse",
     "tags": "signal",
     "class": "ionicons ion-ios-pulse",
@@ -12844,6 +14449,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-pulse-strong",
     "tags": "signal",
     "class": "ionicons ion-ios-pulse-strong",
@@ -12852,6 +14458,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-rainy",
     "tags": "weather, cloud",
     "class": "ionicons ion-ios-rainy",
@@ -12860,6 +14467,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-rainy-outline",
     "tags": "weather, cloud",
     "class": "ionicons ion-ios-rainy-outline",
@@ -12868,6 +14476,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-recording",
     "tags": "video player, tape, reels",
     "class": "ionicons ion-ios-recording",
@@ -12876,6 +14485,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-recording-outline",
     "tags": "video player, tape, reels",
     "class": "ionicons ion-ios-recording-outline",
@@ -12884,6 +14494,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-redo",
     "tags": "text editor, arrow",
     "class": "ionicons ion-ios-redo",
@@ -12892,6 +14503,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-redo-outline",
     "tags": "text editor, arrow",
     "class": "ionicons ion-ios-redo-outline",
@@ -12900,6 +14512,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-refresh",
     "tags": "reload",
     "class": "ionicons ion-ios-refresh",
@@ -12908,6 +14521,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-refresh-empty",
     "tags": "reload",
     "class": "ionicons ion-ios-refresh-empty",
@@ -12916,6 +14530,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-refresh-outline",
     "tags": "reload",
     "class": "ionicons ion-ios-refresh-outline",
@@ -12924,6 +14539,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-reload",
     "tags": "refresh",
     "class": "ionicons ion-ios-reload",
@@ -12932,6 +14548,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-reverse-camera",
     "tags": "",
     "class": "ionicons ion-ios-reverse-camera",
@@ -12940,6 +14557,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-reverse-camera-outline",
     "tags": "",
     "class": "ionicons ion-ios-reverse-camera-outline",
@@ -12948,6 +14566,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-rewind",
     "tags": "video player",
     "class": "ionicons ion-ios-rewind",
@@ -12956,6 +14575,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-rewind-outline",
     "tags": "video player",
     "class": "ionicons ion-ios-rewind-outline",
@@ -12964,6 +14584,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-rose",
     "tags": "flower",
     "class": "ionicons ion-ios-rose",
@@ -12972,6 +14593,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-rose-outline",
     "tags": "flower",
     "class": "ionicons ion-ios-rose-outline",
@@ -12980,6 +14602,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-search",
     "tags": "magnifying glass",
     "class": "ionicons ion-ios-search",
@@ -12988,6 +14611,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-search-strong",
     "tags": "magnifying glass",
     "class": "ionicons ion-ios-search-strong",
@@ -12996,6 +14620,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-settings",
     "tags": "equalizer, levels",
     "class": "ionicons ion-ios-settings",
@@ -13004,6 +14629,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-settings-strong",
     "tags": "equalizer, levels",
     "class": "ionicons ion-ios-settings-strong",
@@ -13012,6 +14638,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-shuffle",
     "tags": "random",
     "class": "ionicons ion-ios-shuffle",
@@ -13020,6 +14647,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-shuffle-strong",
     "tags": "random",
     "class": "ionicons ion-ios-shuffle-strong",
@@ -13028,6 +14656,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-skipbackward",
     "tags": "video player",
     "class": "ionicons ion-ios-skipbackward",
@@ -13036,6 +14665,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-skipbackward-outline",
     "tags": "video player",
     "class": "ionicons ion-ios-skipbackward-outline",
@@ -13044,6 +14674,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-skipforward",
     "tags": "video player",
     "class": "ionicons ion-ios-skipforward",
@@ -13052,6 +14683,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-skipforward-outline",
     "tags": "video player",
     "class": "ionicons ion-ios-skipforward-outline",
@@ -13060,6 +14692,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-snowy",
     "tags": "weather, snowflake, winter",
     "class": "ionicons ion-ios-snowy",
@@ -13068,6 +14701,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-speedometer",
     "tags": "dashboard, tachometer",
     "class": "ionicons ion-ios-speedometer",
@@ -13076,6 +14710,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-speedometer-outline",
     "tags": "dashboard, tachometer",
     "class": "ionicons ion-ios-speedometer-outline",
@@ -13084,6 +14719,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-star",
     "tags": "like, favorite, rate, ratings",
     "class": "ionicons ion-ios-star",
@@ -13092,6 +14728,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-star-half",
     "tags": "rate, ratings",
     "class": "ionicons ion-ios-star-half",
@@ -13100,6 +14737,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-star-outline",
     "tags": "like, favorite, rate, ratings",
     "class": "ionicons ion-ios-star-outline",
@@ -13108,6 +14746,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-stopwatch",
     "tags": "timer, clock",
     "class": "ionicons ion-ios-stopwatch",
@@ -13116,6 +14755,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-stopwatch-outline",
     "tags": "timer, clock",
     "class": "ionicons ion-ios-stopwatch-outline",
@@ -13124,6 +14764,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-sunny",
     "tags": "weather",
     "class": "ionicons ion-ios-sunny",
@@ -13132,6 +14773,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-sunny-outline",
     "tags": "weather",
     "class": "ionicons ion-ios-sunny-outline",
@@ -13140,6 +14782,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-telephone",
     "tags": "",
     "class": "ionicons ion-ios-telephone",
@@ -13148,6 +14791,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-telephone-outline",
     "tags": "",
     "class": "ionicons ion-ios-telephone-outline",
@@ -13156,6 +14800,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-tennisball",
     "tags": "sports",
     "class": "ionicons ion-ios-tennisball",
@@ -13164,6 +14809,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-tennisball-outline",
     "tags": "sports",
     "class": "ionicons ion-ios-tennisball-outline",
@@ -13172,6 +14818,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-thunderstorm",
     "tags": "weather, cloud, lightning",
     "class": "ionicons ion-ios-thunderstorm",
@@ -13180,6 +14827,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-thunderstorm-outline",
     "tags": "weather, cloud, lightning",
     "class": "ionicons ion-ios-thunderstorm-outline",
@@ -13188,6 +14836,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-time",
     "tags": "clock",
     "class": "ionicons ion-ios-time",
@@ -13196,6 +14845,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-time-outline",
     "tags": "clock",
     "class": "ionicons ion-ios-time-outline",
@@ -13204,6 +14854,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-timer",
     "tags": "clock",
     "class": "ionicons ion-ios-timer",
@@ -13212,6 +14863,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-timer-outline",
     "tags": "clock",
     "class": "ionicons ion-ios-timer-outline",
@@ -13220,6 +14872,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-toggle",
     "tags": "settings",
     "class": "ionicons ion-ios-toggle",
@@ -13228,6 +14881,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-toggle-outline",
     "tags": "settings",
     "class": "ionicons ion-ios-toggle-outline",
@@ -13236,6 +14890,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-trash",
     "tags": "delete",
     "class": "ionicons ion-ios-trash",
@@ -13244,6 +14899,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-trash-outline",
     "tags": "delete",
     "class": "ionicons ion-ios-trash-outline",
@@ -13252,6 +14908,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-undo",
     "tags": "text editor, arrow",
     "class": "ionicons ion-ios-undo",
@@ -13260,6 +14917,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-undo-outline",
     "tags": "text editor, arrow",
     "class": "ionicons ion-ios-undo-outline",
@@ -13268,6 +14926,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-unlocked",
     "tags": "",
     "class": "ionicons ion-ios-unlocked",
@@ -13276,6 +14935,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-unlocked-outline",
     "tags": "",
     "class": "ionicons ion-ios-unlocked-outline",
@@ -13284,6 +14944,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-upload",
     "tags": "",
     "class": "ionicons ion-ios-upload",
@@ -13292,6 +14953,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-upload-outline",
     "tags": "",
     "class": "ionicons ion-ios-upload-outline",
@@ -13300,6 +14962,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-videocam",
     "tags": "camera",
     "class": "ionicons ion-ios-videocam",
@@ -13308,6 +14971,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-videocam-outline",
     "tags": "camera",
     "class": "ionicons ion-ios-videocam-outline",
@@ -13316,6 +14980,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-volume-high",
     "tags": "audio, sound",
     "class": "ionicons ion-ios-volume-high",
@@ -13324,6 +14989,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-volume-low",
     "tags": "audio, sound",
     "class": "ionicons ion-ios-volume-low",
@@ -13332,6 +14998,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-wineglass",
     "tags": "drink, glass, alcohol",
     "class": "ionicons ion-ios-wineglass",
@@ -13340,6 +15007,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-wineglass-outline",
     "tags": "drink, glass, alcohol",
     "class": "ionicons ion-ios-wineglass-outline",
@@ -13348,6 +15016,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-world",
     "tags": "globe, earth, planet",
     "class": "ionicons ion-ios-world",
@@ -13356,6 +15025,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ios-world-outline",
     "tags": "globe, earth, planet",
     "class": "ionicons ion-ios-world-outline",
@@ -13364,6 +15034,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ipad",
     "tags": "brand, apple, device, computer",
     "class": "ionicons ion-ipad",
@@ -13372,6 +15043,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "iphone",
     "tags": "brand, apple, device, mobile phone",
     "class": "ionicons ion-iphone",
@@ -13380,6 +15052,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ipod",
     "tags": "brand, apple, device, music, mp3",
     "class": "ionicons ion-ipod",
@@ -13388,6 +15061,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "jet",
     "tags": "airplane",
     "class": "ionicons ion-jet",
@@ -13396,6 +15070,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "key",
     "tags": "secure",
     "class": "ionicons ion-key",
@@ -13404,6 +15079,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "knife",
     "tags": "cutlery, dining, food",
     "class": "ionicons ion-knife",
@@ -13412,6 +15088,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "laptop",
     "tags": "computer",
     "class": "ionicons ion-laptop",
@@ -13420,6 +15097,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "leaf",
     "tags": "plant, nature",
     "class": "ionicons ion-leaf",
@@ -13428,6 +15106,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "levels",
     "tags": "audio, settings, equalizer",
     "class": "ionicons ion-levels",
@@ -13436,6 +15115,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "lightbulb",
     "tags": "",
     "class": "ionicons ion-lightbulb",
@@ -13444,6 +15124,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "link",
     "tags": "chain",
     "class": "ionicons ion-link",
@@ -13452,6 +15133,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "load-a",
     "tags": "loading",
     "class": "ionicons ion-load-a",
@@ -13460,6 +15142,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "load-b",
     "tags": "loading",
     "class": "ionicons ion-load-b",
@@ -13468,6 +15151,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "load-c",
     "tags": "loading",
     "class": "ionicons ion-load-c",
@@ -13476,6 +15160,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "load-d",
     "tags": "loading",
     "class": "ionicons ion-load-d",
@@ -13484,6 +15169,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "location",
     "tags": "map marker",
     "class": "ionicons ion-location",
@@ -13492,6 +15178,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "lock-combination",
     "tags": "",
     "class": "ionicons ion-lock-combination",
@@ -13500,6 +15187,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "locked",
     "tags": "",
     "class": "ionicons ion-locked",
@@ -13508,6 +15196,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "log-in",
     "tags": "",
     "class": "ionicons ion-log-in",
@@ -13516,6 +15205,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "log-out",
     "tags": "",
     "class": "ionicons ion-log-out",
@@ -13524,6 +15214,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "loop",
     "tags": "refresh, reload",
     "class": "ionicons ion-loop",
@@ -13532,6 +15223,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "magnet",
     "tags": "",
     "class": "ionicons ion-magnet",
@@ -13540,6 +15232,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "male",
     "tags": "gender, sex, mars",
     "class": "ionicons ion-male",
@@ -13548,6 +15241,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "man",
     "tags": "gender, sex, user, person",
     "class": "ionicons ion-man",
@@ -13556,6 +15250,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "map",
     "tags": "",
     "class": "ionicons ion-map",
@@ -13564,6 +15259,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "medkit",
     "tags": "medical, health, hospital",
     "class": "ionicons ion-medkit",
@@ -13572,6 +15268,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "merge",
     "tags": "git",
     "class": "ionicons ion-merge",
@@ -13580,6 +15277,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "mic-a",
     "tags": "audio",
     "class": "ionicons ion-mic-a",
@@ -13588,6 +15286,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "mic-b",
     "tags": "audio",
     "class": "ionicons ion-mic-b",
@@ -13596,6 +15295,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "mic-c",
     "tags": "audio",
     "class": "ionicons ion-mic-c",
@@ -13604,6 +15304,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "minus",
     "tags": "bar, remove",
     "class": "ionicons ion-minus",
@@ -13612,6 +15313,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "minus-circled",
     "tags": "bar, remove",
     "class": "ionicons ion-minus-circled",
@@ -13620,6 +15322,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "minus-round",
     "tags": "bar, remove",
     "class": "ionicons ion-minus-round",
@@ -13628,6 +15331,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "model-s",
     "tags": "automobile, car, tesla",
     "class": "ionicons ion-model-s",
@@ -13636,6 +15340,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "monitor",
     "tags": "computer, display",
     "class": "ionicons ion-monitor",
@@ -13644,6 +15349,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "more",
     "tags": "dots, menu",
     "class": "ionicons ion-more",
@@ -13652,6 +15358,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "mouse",
     "tags": "",
     "class": "ionicons ion-mouse",
@@ -13660,6 +15367,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "music-note",
     "tags": "song",
     "class": "ionicons ion-music-note",
@@ -13668,6 +15376,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "navicon",
     "tags": "hamburger menu, more, bars",
     "class": "ionicons ion-navicon",
@@ -13676,6 +15385,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "navicon-round",
     "tags": "hamburger menu, more, bars",
     "class": "ionicons ion-navicon-round",
@@ -13684,6 +15394,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "navigate",
     "tags": "marker, arrow",
     "class": "ionicons ion-navigate",
@@ -13692,6 +15403,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "network",
     "tags": "",
     "class": "ionicons ion-network",
@@ -13700,6 +15412,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "no-smoking",
     "tags": "",
     "class": "ionicons ion-no-smoking",
@@ -13708,6 +15421,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "nuclear",
     "tags": "warning, danger",
     "class": "ionicons ion-nuclear",
@@ -13716,6 +15430,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "outlet",
     "tags": "",
     "class": "ionicons ion-outlet",
@@ -13724,6 +15439,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "paintbrush",
     "tags": "art",
     "class": "ionicons ion-paintbrush",
@@ -13732,6 +15448,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "paintbucket",
     "tags": "fill, pour",
     "class": "ionicons ion-paintbucket",
@@ -13740,6 +15457,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "paper-airplane",
     "tags": "",
     "class": "ionicons ion-paper-airplane",
@@ -13748,6 +15466,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "paperclip",
     "tags": "email, file attachment",
     "class": "ionicons ion-paperclip",
@@ -13756,6 +15475,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "pause",
     "tags": "",
     "class": "ionicons ion-pause",
@@ -13764,6 +15484,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "person",
     "tags": "user, head",
     "class": "ionicons ion-person",
@@ -13772,6 +15493,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "person-add",
     "tags": "user, head",
     "class": "ionicons ion-person-add",
@@ -13780,6 +15502,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "person-stalker",
     "tags": "users, people",
     "class": "ionicons ion-person-stalker",
@@ -13788,6 +15511,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "pie-graph",
     "tags": "chart",
     "class": "ionicons ion-pie-graph",
@@ -13796,6 +15520,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "pin",
     "tags": "thumbtack",
     "class": "ionicons ion-pin",
@@ -13804,6 +15529,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "pinpoint",
     "tags": "aim, reticle, target",
     "class": "ionicons ion-pinpoint",
@@ -13812,6 +15538,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "pizza",
     "tags": "food",
     "class": "ionicons ion-pizza",
@@ -13820,6 +15547,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "plane",
     "tags": "airplane",
     "class": "ionicons ion-plane",
@@ -13828,6 +15556,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "planet",
     "tags": "saturn, space",
     "class": "ionicons ion-planet",
@@ -13836,6 +15565,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "play",
     "tags": "video player, triangle",
     "class": "ionicons ion-play",
@@ -13844,6 +15574,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "playstation",
     "tags": "brand, logo, sony, video games",
     "class": "ionicons ion-playstation",
@@ -13852,6 +15583,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "plus",
     "tags": "add",
     "class": "ionicons ion-plus",
@@ -13860,6 +15592,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "plus-circled",
     "tags": "add",
     "class": "ionicons ion-plus-circled",
@@ -13868,6 +15601,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "plus-round",
     "tags": "add",
     "class": "ionicons ion-plus-round",
@@ -13876,6 +15610,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "podium",
     "tags": "bars",
     "class": "ionicons ion-podium",
@@ -13884,6 +15619,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "pound",
     "tags": "hash, number",
     "class": "ionicons ion-pound",
@@ -13892,6 +15628,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "power",
     "tags": "off, on",
     "class": "ionicons ion-power",
@@ -13900,6 +15637,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "pricetag",
     "tags": "shopping",
     "class": "ionicons ion-pricetag",
@@ -13908,6 +15646,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "pricetags",
     "tags": "shopping",
     "class": "ionicons ion-pricetags",
@@ -13916,6 +15655,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "printer",
     "tags": "computer",
     "class": "ionicons ion-printer",
@@ -13924,6 +15664,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "pull-request",
     "tags": "github",
     "class": "ionicons ion-pull-request",
@@ -13932,6 +15673,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "qr-scanner",
     "tags": "",
     "class": "ionicons ion-qr-scanner",
@@ -13940,6 +15682,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "quote",
     "tags": "",
     "class": "ionicons ion-quote",
@@ -13948,6 +15691,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "radio-waves",
     "tags": "sound, broadcast, signal",
     "class": "ionicons ion-radio-waves",
@@ -13956,6 +15700,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "record",
     "tags": "video player, circle",
     "class": "ionicons ion-record",
@@ -13964,6 +15709,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "refresh",
     "tags": "reload",
     "class": "ionicons ion-refresh",
@@ -13972,6 +15718,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "reply",
     "tags": "email",
     "class": "ionicons ion-reply",
@@ -13980,6 +15727,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "reply-all",
     "tags": "email",
     "class": "ionicons ion-reply-all",
@@ -13988,6 +15736,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ribbon-a",
     "tags": "award, medal, prize",
     "class": "ionicons ion-ribbon-a",
@@ -13996,6 +15745,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "ribbon-b",
     "tags": "award, medal, prize",
     "class": "ionicons ion-ribbon-b",
@@ -14004,6 +15754,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "sad",
     "tags": "face, frown",
     "class": "ionicons ion-sad",
@@ -14012,6 +15763,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "sad-outline",
     "tags": "face, frown",
     "class": "ionicons ion-sad-outline",
@@ -14020,6 +15772,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "scissors",
     "tags": "cut",
     "class": "ionicons ion-scissors",
@@ -14028,6 +15781,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "search",
     "tags": "magnifying glass",
     "class": "ionicons ion-search",
@@ -14036,6 +15790,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "settings",
     "tags": "tools",
     "class": "ionicons ion-settings",
@@ -14044,6 +15799,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "share",
     "tags": "",
     "class": "ionicons ion-share",
@@ -14052,6 +15808,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "shuffle",
     "tags": "video player",
     "class": "ionicons ion-shuffle",
@@ -14060,6 +15817,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "skip-backward",
     "tags": "video player",
     "class": "ionicons ion-skip-backward",
@@ -14068,6 +15826,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "skip-forward",
     "tags": "video payer",
     "class": "ionicons ion-skip-forward",
@@ -14076,6 +15835,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "social-android",
     "tags": "brand, logo, google",
     "class": "ionicons ion-social-android",
@@ -14084,6 +15844,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "social-android-outline",
     "tags": "brand, logo, google",
     "class": "ionicons ion-social-android-outline",
@@ -14092,6 +15853,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "social-angular",
     "tags": "brand, logo",
     "class": "ionicons ion-social-angular",
@@ -14100,6 +15862,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "social-angular-outline",
     "tags": "brand, logo",
     "class": "ionicons ion-social-angular-outline",
@@ -14108,6 +15871,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "social-apple",
     "tags": "brand, logo",
     "class": "ionicons ion-social-apple",
@@ -14116,6 +15880,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "social-apple-outline",
     "tags": "brand, logo",
     "class": "ionicons ion-social-apple-outline",
@@ -14124,6 +15889,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "social-bitcoin",
     "tags": "currency, money",
     "class": "ionicons ion-social-bitcoin",
@@ -14132,6 +15898,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "social-bitcoin-outline",
     "tags": "currency, money",
     "class": "ionicons ion-social-bitcoin-outline",
@@ -14140,6 +15907,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "social-buffer",
     "tags": "brand, logo",
     "class": "ionicons ion-social-buffer",
@@ -14148,6 +15916,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "social-buffer-outline",
     "tags": "brand, logo",
     "class": "ionicons ion-social-buffer-outline",
@@ -14156,6 +15925,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "social-chrome",
     "tags": "brand, browser, logo",
     "class": "ionicons ion-social-chrome",
@@ -14164,6 +15934,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "social-chrome-outline",
     "tags": "brand, browser, logo",
     "class": "ionicons ion-social-chrome-outline",
@@ -14172,6 +15943,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "social-codepen",
     "tags": "brand, logo",
     "class": "ionicons ion-social-codepen",
@@ -14180,6 +15952,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "social-codepen-outline",
     "tags": "brand, logo",
     "class": "ionicons ion-social-codepen-outline",
@@ -14188,6 +15961,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "social-css3",
     "tags": "brand, logo",
     "class": "ionicons ion-social-css3",
@@ -14196,6 +15970,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "social-css3-outline",
     "tags": "brand, logo",
     "class": "ionicons ion-social-css3-outline",
@@ -14204,6 +15979,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "social-designernews",
     "tags": "brand, logo",
     "class": "ionicons ion-social-designernews",
@@ -14212,6 +15988,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "social-designernews-outline",
     "tags": "brand, logo",
     "class": "ionicons ion-social-designernews-outline",
@@ -14220,6 +15997,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "social-dribbble",
     "tags": "brand, logo, basketball",
     "class": "ionicons ion-social-dribbble",
@@ -14228,6 +16006,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "social-dribbble-outline",
     "tags": "brand, logo, basketball",
     "class": "ionicons ion-social-dribbble-outline",
@@ -14236,6 +16015,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "social-dropbox",
     "tags": "brand, logo",
     "class": "ionicons ion-social-dropbox",
@@ -14244,6 +16024,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "social-dropbox-outline",
     "tags": "brand, logo",
     "class": "ionicons ion-social-dropbox-outline",
@@ -14252,6 +16033,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "social-euro",
     "tags": "currency, money",
     "class": "ionicons ion-social-euro",
@@ -14260,6 +16042,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "social-euro-outline",
     "tags": "currency, money",
     "class": "ionicons ion-social-euro-outline",
@@ -14268,6 +16051,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "social-facebook",
     "tags": "brand, logo",
     "class": "ionicons ion-social-facebook",
@@ -14276,6 +16060,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "social-facebook-outline",
     "tags": "brand, logo",
     "class": "ionicons ion-social-facebook-outline",
@@ -14284,6 +16069,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "social-foursquare",
     "tags": "brand, logo",
     "class": "ionicons ion-social-foursquare",
@@ -14292,6 +16078,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "social-foursquare-outline",
     "tags": "brand, logo",
     "class": "ionicons ion-social-foursquare-outline",
@@ -14300,6 +16087,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "social-freebsd-devil",
     "tags": "",
     "class": "ionicons ion-social-freebsd-devil",
@@ -14308,6 +16096,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "social-github",
     "tags": "brand, logo, code",
     "class": "ionicons ion-social-github",
@@ -14316,6 +16105,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "social-github-outline",
     "tags": "brand, logo, code",
     "class": "ionicons ion-social-github-outline",
@@ -14324,6 +16114,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "social-google",
     "tags": "brand, logo",
     "class": "ionicons ion-social-google",
@@ -14332,6 +16123,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "social-google-outline",
     "tags": "brand, logo",
     "class": "ionicons ion-social-google-outline",
@@ -14340,6 +16132,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "social-googleplus",
     "tags": "brand, logo",
     "class": "ionicons ion-social-googleplus",
@@ -14348,6 +16141,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "social-googleplus-outline",
     "tags": "brand, logo",
     "class": "ionicons ion-social-googleplus-outline",
@@ -14356,6 +16150,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "social-hackernews",
     "tags": "brand, logo",
     "class": "ionicons ion-social-hackernews",
@@ -14364,6 +16159,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "social-hackernews-outline",
     "tags": "brand, logo",
     "class": "ionicons ion-social-hackernews-outline",
@@ -14372,6 +16168,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "social-html5",
     "tags": "brand",
     "class": "ionicons ion-social-html5",
@@ -14380,6 +16177,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "social-html5-outline",
     "tags": "brand, logo",
     "class": "ionicons ion-social-html5-outline",
@@ -14388,6 +16186,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "social-instagram",
     "tags": "brand, logo",
     "class": "ionicons ion-social-instagram",
@@ -14396,6 +16195,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "social-instagram-outline",
     "tags": "brand, logo",
     "class": "ionicons ion-social-instagram-outline",
@@ -14404,6 +16204,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "social-javascript",
     "tags": "brand, logo",
     "class": "ionicons ion-social-javascript",
@@ -14412,6 +16213,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "social-javascript-outline",
     "tags": "brand, logo",
     "class": "ionicons ion-social-javascript-outline",
@@ -14420,6 +16222,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "social-linkedin",
     "tags": "brand, logo",
     "class": "ionicons ion-social-linkedin",
@@ -14428,6 +16231,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "social-linkedin-outline",
     "tags": "brand, logo",
     "class": "ionicons ion-social-linkedin-outline",
@@ -14436,6 +16240,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "social-markdown",
     "tags": "brand, logo",
     "class": "ionicons ion-social-markdown",
@@ -14444,6 +16249,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "social-nodejs",
     "tags": "brand, logo",
     "class": "ionicons ion-social-nodejs",
@@ -14452,6 +16258,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "social-octocat",
     "tags": "brand, logo, github",
     "class": "ionicons ion-social-octocat",
@@ -14460,6 +16267,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "social-pinterest",
     "tags": "brand, logo",
     "class": "ionicons ion-social-pinterest",
@@ -14468,6 +16276,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "social-pinterest-outline",
     "tags": "brand, logo",
     "class": "ionicons ion-social-pinterest-outline",
@@ -14476,6 +16285,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "social-python",
     "tags": "brand, logo,",
     "class": "ionicons ion-social-python",
@@ -14484,6 +16294,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "social-reddit",
     "tags": "brand, logo, alien",
     "class": "ionicons ion-social-reddit",
@@ -14492,6 +16303,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "social-reddit-outline",
     "tags": "brand, logo, alien",
     "class": "ionicons ion-social-reddit-outline",
@@ -14500,6 +16312,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "social-rss",
     "tags": "brand, logo",
     "class": "ionicons ion-social-rss",
@@ -14508,6 +16321,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "social-rss-outline",
     "tags": "brand, logo",
     "class": "ionicons ion-social-rss-outline",
@@ -14516,6 +16330,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "social-sass",
     "tags": "brand, logo",
     "class": "ionicons ion-social-sass",
@@ -14524,6 +16339,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "social-skype",
     "tags": "brand, logo",
     "class": "ionicons ion-social-skype",
@@ -14532,6 +16348,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "social-skype-outline",
     "tags": "brand, logo",
     "class": "ionicons ion-social-skype-outline",
@@ -14540,6 +16357,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "social-snapchat",
     "tags": "brand, logo",
     "class": "ionicons ion-social-snapchat",
@@ -14548,6 +16366,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "social-snapchat-outline",
     "tags": "brand, logo",
     "class": "ionicons ion-social-snapchat-outline",
@@ -14556,6 +16375,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "social-tumblr",
     "tags": "brand, logo, yahoo",
     "class": "ionicons ion-social-tumblr",
@@ -14564,6 +16384,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "social-tumblr-outline",
     "tags": "brand, logo, yahoo",
     "class": "ionicons ion-social-tumblr-outline",
@@ -14572,6 +16393,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "social-tux",
     "tags": "brand, logo, bird, linux, penguin",
     "class": "ionicons ion-social-tux",
@@ -14580,6 +16402,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "social-twitch",
     "tags": "brand, logo",
     "class": "ionicons ion-social-twitch",
@@ -14588,6 +16411,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "social-twitch-outline",
     "tags": "brand, logo",
     "class": "ionicons ion-social-twitch-outline",
@@ -14596,6 +16420,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "social-twitter",
     "tags": "brand, logo",
     "class": "ionicons ion-social-twitter",
@@ -14604,6 +16429,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "social-twitter-outline",
     "tags": "brand, logo",
     "class": "ionicons ion-social-twitter-outline",
@@ -14612,6 +16438,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "social-usd",
     "tags": "currency, dollar, money",
     "class": "ionicons ion-social-usd",
@@ -14620,6 +16447,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "social-usd-outline",
     "tags": "currency, dollar, money",
     "class": "ionicons ion-social-usd-outline",
@@ -14628,6 +16456,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "social-vimeo",
     "tags": "brand, logo",
     "class": "ionicons ion-social-vimeo",
@@ -14636,6 +16465,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "social-vimeo-outline",
     "tags": "brand, logo",
     "class": "ionicons ion-social-vimeo-outline",
@@ -14644,6 +16474,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "social-whatsapp",
     "tags": "brand, logo",
     "class": "ionicons ion-social-whatsapp",
@@ -14652,6 +16483,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "social-whatsapp-outline",
     "tags": "brand, logo",
     "class": "ionicons ion-social-whatsapp-outline",
@@ -14660,6 +16492,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "social-windows",
     "tags": "brand, logo, microsoft",
     "class": "ionicons ion-social-windows",
@@ -14668,6 +16501,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "social-windows-outline",
     "tags": "brand, logo, microsoft",
     "class": "ionicons ion-social-windows-outline",
@@ -14676,6 +16510,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "social-wordpress",
     "tags": "brand, logo",
     "class": "ionicons ion-social-wordpress",
@@ -14684,6 +16519,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "social-wordpress-outline",
     "tags": "brand, logo",
     "class": "ionicons ion-social-wordpress-outline",
@@ -14692,6 +16528,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "social-yahoo",
     "tags": "brand, logo",
     "class": "ionicons ion-social-yahoo",
@@ -14700,6 +16537,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "social-yahoo-outline",
     "tags": "brand, logo",
     "class": "ionicons ion-social-yahoo-outline",
@@ -14708,6 +16546,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "social-yen",
     "tags": "currency, money",
     "class": "ionicons ion-social-yen",
@@ -14716,6 +16555,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "social-yen-outline",
     "tags": "currency, money",
     "class": "ionicons ion-social-yen-outline",
@@ -14724,6 +16564,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "social-youtube",
     "tags": "brand, logo, video",
     "class": "ionicons ion-social-youtube",
@@ -14732,6 +16573,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "social-youtube-outline",
     "tags": "brand, logo, video",
     "class": "ionicons ion-social-youtube-outline",
@@ -14740,6 +16582,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "soup-can",
     "tags": "food",
     "class": "ionicons ion-soup-can",
@@ -14748,6 +16591,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "soup-can-outline",
     "tags": "food",
     "class": "ionicons ion-soup-can-outline",
@@ -14756,6 +16600,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "speakerphone",
     "tags": "bullhorn",
     "class": "ionicons ion-speakerphone",
@@ -14764,6 +16609,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "speedometer",
     "tags": "dashboard, tachometer",
     "class": "ionicons ion-speedometer",
@@ -14772,6 +16618,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "spoon",
     "tags": "cutlery, dining, food",
     "class": "ionicons ion-spoon",
@@ -14780,6 +16627,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "star",
     "tags": "like, rate, ratings",
     "class": "ionicons ion-star",
@@ -14788,6 +16636,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "stats-bars",
     "tags": "graph",
     "class": "ionicons ion-stats-bars",
@@ -14796,6 +16645,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "steam",
     "tags": "brand, logo, social",
     "class": "ionicons ion-steam",
@@ -14804,6 +16654,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "stop",
     "tags": "video player, square",
     "class": "ionicons ion-stop",
@@ -14812,6 +16663,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "thermometer",
     "tags": "temperature",
     "class": "ionicons ion-thermometer",
@@ -14820,6 +16672,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "thumbsdown",
     "tags": "dislike, ratings",
     "class": "ionicons ion-thumbsdown",
@@ -14828,6 +16681,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "thumbsup",
     "tags": "like, ratings",
     "class": "ionicons ion-thumbsup",
@@ -14836,6 +16690,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "toggle",
     "tags": "setting",
     "class": "ionicons ion-toggle",
@@ -14844,6 +16699,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "toggle-filled",
     "tags": "setting",
     "class": "ionicons ion-toggle-filled",
@@ -14852,6 +16708,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "transgender",
     "tags": "",
     "class": "ionicons ion-transgender",
@@ -14860,6 +16717,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "trash-a",
     "tags": "delete",
     "class": "ionicons ion-trash-a",
@@ -14868,6 +16726,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "trash-b",
     "tags": "delete",
     "class": "ionicons ion-trash-b",
@@ -14876,6 +16735,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "trophy",
     "tags": "award, prize",
     "class": "ionicons ion-trophy",
@@ -14884,6 +16744,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "tshirt",
     "tags": "clothes",
     "class": "ionicons ion-tshirt",
@@ -14892,6 +16753,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "tshirt-outline",
     "tags": "clothes",
     "class": "ionicons ion-tshirt-outline",
@@ -14900,6 +16762,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "umbrella",
     "tags": "weather",
     "class": "ionicons ion-umbrella",
@@ -14908,6 +16771,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "university",
     "tags": "education, graduate",
     "class": "ionicons ion-university",
@@ -14916,6 +16780,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "unlocked",
     "tags": "",
     "class": "ionicons ion-unlocked",
@@ -14924,6 +16789,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "upload",
     "tags": "",
     "class": "ionicons ion-upload",
@@ -14932,6 +16798,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "usb",
     "tags": "",
     "class": "ionicons ion-usb",
@@ -14940,6 +16807,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "videocamera",
     "tags": "",
     "class": "ionicons ion-videocamera",
@@ -14948,6 +16816,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "volume-high",
     "tags": "audio, sound",
     "class": "ionicons ion-volume-high",
@@ -14956,6 +16825,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "volume-low",
     "tags": "audio, sound",
     "class": "ionicons ion-volume-low",
@@ -14964,6 +16834,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "volume-medium",
     "tags": "audio, sound",
     "class": "ionicons ion-volume-medium",
@@ -14972,6 +16843,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "volume-mute",
     "tags": "audio, sound",
     "class": "ionicons ion-volume-mute",
@@ -14980,6 +16852,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "wand",
     "tags": "magic",
     "class": "ionicons ion-wand",
@@ -14988,6 +16861,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "waterdrop",
     "tags": "rain, weather",
     "class": "ionicons ion-waterdrop",
@@ -14996,6 +16870,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "wifi",
     "tags": "signal",
     "class": "ionicons ion-wifi",
@@ -15004,6 +16879,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "wineglass",
     "tags": "drink, glass, alcohol",
     "class": "ionicons ion-wineglass",
@@ -15012,6 +16888,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "woman",
     "tags": "gender, sex, person",
     "class": "ionicons ion-woman",
@@ -15020,6 +16897,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "wrench",
     "tags": "tool, settings",
     "class": "ionicons ion-wrench",
@@ -15028,6 +16906,7 @@
   },
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "xbox",
     "tags": "brand, logo, video game",
     "class": "ionicons ion-xbox",
@@ -15037,6 +16916,7 @@
 
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "accessibility",
     "tags": "person",
     "class": "icomoon icon-accessibility",
@@ -15045,6 +16925,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "address-book",
     "tags": "contacts",
     "class": "icomoon icon-address-book",
@@ -15053,6 +16934,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "aid",
     "tags": "medical",
     "class": "icomoon icon-aid",
@@ -15061,6 +16943,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "airplane",
     "tags": "transportation",
     "class": "icomoon icon-airplane",
@@ -15069,6 +16952,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "alarm",
     "tags": "clock, timer",
     "class": "icomoon icon-alarm",
@@ -15077,6 +16961,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "alarm-2",
     "tags": "clock, timer",
     "class": "icomoon icon-alarm-2",
@@ -15085,6 +16970,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "android",
     "tags": "brand, logo",
     "class": "icomoon icon-android",
@@ -15093,6 +16979,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "angry",
     "tags": "frown, smiley face",
     "class": "icomoon icon-angry",
@@ -15101,6 +16988,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "angry-2",
     "tags": "frown, smiley face",
     "class": "icomoon icon-angry-2",
@@ -15109,6 +16997,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "apple",
     "tags": "brand, logo",
     "class": "icomoon icon-apple",
@@ -15117,6 +17006,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "arrow-down-left",
     "tags": "directional",
     "class": "icomoon icon-arrow-down-left",
@@ -15125,6 +17015,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "arrow-down-left-2",
     "tags": "directional",
     "class": "icomoon icon-arrow-down-left-2",
@@ -15133,6 +17024,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "arrow-down-left-3",
     "tags": "directional",
     "class": "icomoon icon-arrow-down-left-3",
@@ -15141,6 +17033,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "arrow-down-right",
     "tags": "directional",
     "class": "icomoon icon-arrow-down-right",
@@ -15149,6 +17042,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "arrow-down-right-2",
     "tags": "directional",
     "class": "icomoon icon-arrow-down-right-2",
@@ -15157,6 +17051,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "arrow-down-right-3",
     "tags": "directional",
     "class": "icomoon icon-arrow-down-right-3",
@@ -15165,6 +17060,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "arrow-down",
     "tags": "directional",
     "class": "icomoon icon-arrow-down",
@@ -15173,6 +17069,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "arrow-down-2",
     "tags": "directional",
     "class": "icomoon icon-arrow-down-2",
@@ -15181,6 +17078,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "arrow-down-3",
     "tags": "directional",
     "class": "icomoon icon-arrow-down-3",
@@ -15189,6 +17087,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "arrow-left",
     "tags": "directional",
     "class": "icomoon icon-arrow-left",
@@ -15197,6 +17096,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "arrow-left-2",
     "tags": "directional",
     "class": "icomoon icon-arrow-left-2",
@@ -15205,6 +17105,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "arrow-left-3",
     "tags": "directional",
     "class": "icomoon icon-arrow-left-3",
@@ -15213,6 +17114,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "arrow-right",
     "tags": "directional",
     "class": "icomoon icon-arrow-right",
@@ -15221,6 +17123,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "arrow-right-2",
     "tags": "directional",
     "class": "icomoon icon-arrow-right-2",
@@ -15229,6 +17132,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "arrow-right-3",
     "tags": "directional",
     "class": "icomoon icon-arrow-right-3",
@@ -15237,6 +17141,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "arrow-up-left",
     "tags": "directional",
     "class": "icomoon icon-arrow-up-left",
@@ -15245,6 +17150,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "arrow-up-left-2",
     "tags": "directional",
     "class": "icomoon icon-arrow-up-left-2",
@@ -15253,6 +17159,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "arrow-up-left-3",
     "tags": "directional",
     "class": "icomoon icon-arrow-up-left-3",
@@ -15261,6 +17168,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "arrow-up-right",
     "tags": "directional",
     "class": "icomoon icon-arrow-up-right",
@@ -15269,6 +17177,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "arrow-up-right-2",
     "tags": "directional",
     "class": "icomoon icon-arrow-up-right-2",
@@ -15277,6 +17186,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "arrow-up-right-3",
     "tags": "directional",
     "class": "icomoon icon-arrow-up-right-3",
@@ -15285,6 +17195,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "arrow-up",
     "tags": "directional",
     "class": "icomoon icon-arrow-up",
@@ -15293,6 +17204,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "arrow-up-2",
     "tags": "directional",
     "class": "icomoon icon-arrow-up-2",
@@ -15301,6 +17213,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "arrow-up-3",
     "tags": "directional",
     "class": "icomoon icon-arrow-up-3",
@@ -15309,6 +17222,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "attachment",
     "tags": "email, paperclip",
     "class": "icomoon icon-attachment",
@@ -15317,6 +17231,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "backward",
     "tags": "video player, rewind",
     "class": "icomoon icon-backward",
@@ -15325,6 +17240,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "backward-2",
     "tags": "video player, rewind",
     "class": "icomoon icon-backward-2",
@@ -15333,6 +17249,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "barcode",
     "tags": "",
     "class": "icomoon icon-barcode",
@@ -15341,6 +17258,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "bars",
     "tags": "chart, data, graph",
     "class": "icomoon icon-bars",
@@ -15349,6 +17267,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "bars-2",
     "tags": "chart, data, graph",
     "class": "icomoon icon-bars-2",
@@ -15357,6 +17276,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "bell",
     "tags": "audio, sound",
     "class": "icomoon icon-bell",
@@ -15365,6 +17285,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "binoculars",
     "tags": "",
     "class": "icomoon icon-binoculars",
@@ -15373,6 +17294,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "blocked",
     "tags": "ban, prohibited",
     "class": "icomoon icon-blocked",
@@ -15381,6 +17303,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "blog",
     "tags": "",
     "class": "icomoon icon-blog",
@@ -15389,6 +17312,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "blogger",
     "tags": "brand, logo, social",
     "class": "icomoon icon-blogger",
@@ -15397,6 +17321,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "blogger-2",
     "tags": "brand, logo, social",
     "class": "icomoon icon-blogger-2",
@@ -15405,6 +17330,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "bold",
     "tags": "text editor",
     "class": "icomoon icon-bold",
@@ -15413,6 +17339,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "book",
     "tags": "",
     "class": "icomoon icon-book",
@@ -15421,6 +17348,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "bookmark",
     "tags": "",
     "class": "icomoon icon-bookmark",
@@ -15429,6 +17357,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "bookmarks",
     "tags": "",
     "class": "icomoon icon-bookmarks",
@@ -15437,6 +17366,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "books",
     "tags": "",
     "class": "icomoon icon-books",
@@ -15445,6 +17375,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "box-add",
     "tags": "",
     "class": "icomoon icon-box-add",
@@ -15453,6 +17384,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "box-remove",
     "tags": "",
     "class": "icomoon icon-box-remove",
@@ -15461,6 +17393,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "briefcase",
     "tags": "",
     "class": "icomoon icon-briefcase",
@@ -15469,6 +17402,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "brightness-contrast",
     "tags": "adjust",
     "class": "icomoon icon-brightness-contrast",
@@ -15477,6 +17411,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "brightness-medium",
     "tags": "",
     "class": "icomoon icon-brightness-medium",
@@ -15485,6 +17420,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "bubble",
     "tags": "chat, speech",
     "class": "icomoon icon-bubble",
@@ -15493,6 +17429,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "bubble-2",
     "tags": "chat, speech",
     "class": "icomoon icon-bubble-2",
@@ -15501,6 +17438,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "bubbles",
     "tags": "chat, speech",
     "class": "icomoon icon-bubbles",
@@ -15509,6 +17447,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "bubbles-2",
     "tags": "chat, speech",
     "class": "icomoon icon-bubbles-2",
@@ -15517,6 +17456,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "bubbles-3",
     "tags": "chat, speech",
     "class": "icomoon icon-bubbles-3",
@@ -15525,6 +17465,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "bubbles-4",
     "tags": "chat, speech",
     "class": "icomoon icon-bubbles-4",
@@ -15533,6 +17474,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "bug",
     "tags": "",
     "class": "icomoon icon-bug",
@@ -15541,6 +17483,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "bullhorn",
     "tags": "loudspeaker",
     "class": "icomoon icon-bullhorn",
@@ -15549,6 +17492,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "busy",
     "tags": "hourglass, loading, timer",
     "class": "icomoon icon-busy",
@@ -15557,6 +17501,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "cabinet",
     "tags": "",
     "class": "icomoon icon-cabinet",
@@ -15565,6 +17510,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "calculate",
     "tags": "",
     "class": "icomoon icon-calculate",
@@ -15573,6 +17519,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "calendar",
     "tags": "date",
     "class": "icomoon icon-calendar",
@@ -15581,6 +17528,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "calendar-2",
     "tags": "date",
     "class": "icomoon icon-calendar-2",
@@ -15589,6 +17537,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "camera",
     "tags": "photographs",
     "class": "icomoon icon-camera",
@@ -15597,6 +17546,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "camera-2",
     "tags": "video",
     "class": "icomoon icon-camera-2",
@@ -15605,6 +17555,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "cancel-circle",
     "tags": "",
     "class": "icomoon icon-cancel-circle",
@@ -15613,6 +17564,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "cart",
     "tags": "shopping",
     "class": "icomoon icon-cart",
@@ -15621,6 +17573,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "cart-2",
     "tags": "shopping",
     "class": "icomoon icon-cart-2",
@@ -15629,6 +17582,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "cart-3",
     "tags": "shopping",
     "class": "icomoon icon-cart-3",
@@ -15637,6 +17591,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "checkbox-checked",
     "tags": "",
     "class": "icomoon icon-checkbox-checked",
@@ -15645,6 +17600,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "checkbox-partial",
     "tags": "",
     "class": "icomoon icon-checkbox-partial",
@@ -15653,6 +17609,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "checkbox-unchecked",
     "tags": "",
     "class": "icomoon icon-checkbox-unchecked",
@@ -15661,6 +17618,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "checkmark-circle",
     "tags": "",
     "class": "icomoon icon-checkmark-circle",
@@ -15669,6 +17627,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "checkmark",
     "tags": "",
     "class": "icomoon icon-checkmark",
@@ -15677,6 +17636,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "checkmark-2",
     "tags": "",
     "class": "icomoon icon-checkmark-2",
@@ -15685,6 +17645,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "chrome",
     "tags": "brand, browser, logo",
     "class": "icomoon icon-chrome",
@@ -15693,6 +17654,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "clock",
     "tags": "timer",
     "class": "icomoon icon-clock",
@@ -15701,6 +17663,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "clock-2",
     "tags": "timer",
     "class": "icomoon icon-clock-2",
@@ -15709,6 +17672,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "close",
     "tags": "",
     "class": "icomoon icon-close",
@@ -15717,6 +17681,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "cloud-download",
     "tags": "",
     "class": "icomoon icon-cloud-download",
@@ -15725,6 +17690,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "cloud-upload",
     "tags": "",
     "class": "icomoon icon-cloud-upload",
@@ -15733,6 +17699,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "cloud",
     "tags": "",
     "class": "icomoon icon-cloud",
@@ -15741,6 +17708,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "clubs",
     "tags": "",
     "class": "icomoon icon-clubs",
@@ -15749,6 +17717,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "code",
     "tags": "",
     "class": "icomoon icon-code",
@@ -15757,6 +17726,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "cog",
     "tags": "gear",
     "class": "icomoon icon-cog",
@@ -15765,6 +17735,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "cog-2",
     "tags": "gear",
     "class": "icomoon icon-cog-2",
@@ -15773,6 +17744,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "cogs",
     "tags": "gears",
     "class": "icomoon icon-cogs",
@@ -15781,6 +17753,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "coin",
     "tags": "currency, dollar, money, payment",
     "class": "icomoon icon-coin",
@@ -15789,6 +17762,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "compass",
     "tags": "directions, navigation",
     "class": "icomoon icon-compass",
@@ -15797,6 +17771,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "confused",
     "tags": "smiley face",
     "class": "icomoon icon-confused",
@@ -15805,6 +17780,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "confused-2",
     "tags": "smiley face",
     "class": "icomoon icon-confused-2",
@@ -15813,6 +17789,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "connection",
     "tags": "wifi",
     "class": "icomoon icon-connection",
@@ -15821,6 +17798,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "console",
     "tags": "terminal",
     "class": "icomoon icon-console",
@@ -15829,6 +17807,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "contract",
     "tags": "resize, shrink",
     "class": "icomoon icon-contract",
@@ -15837,6 +17816,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "contract-2",
     "tags": "resize, shrink",
     "class": "icomoon icon-contract-2",
@@ -15845,6 +17825,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "contrast",
     "tags": "adjust",
     "class": "icomoon icon-contrast",
@@ -15853,6 +17834,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "cool",
     "tags": "smiley face, sunglasses",
     "class": "icomoon icon-cool",
@@ -15861,6 +17843,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "cool-2",
     "tags": "smiley face, sunglasses",
     "class": "icomoon icon-cool-2",
@@ -15869,6 +17852,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "copy",
     "tags": "clone, documents, duplicate, files",
     "class": "icomoon icon-copy",
@@ -15877,6 +17861,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "copy-2",
     "tags": "clipboard",
     "class": "icomoon icon-copy-2",
@@ -15885,6 +17870,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "copy-3",
     "tags": "clone, documents, duplicate, files",
     "class": "icomoon icon-copy-3",
@@ -15893,6 +17879,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "credit",
     "tags": "money, payment, shopping",
     "class": "icomoon icon-credit",
@@ -15901,6 +17888,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "crop",
     "tags": "",
     "class": "icomoon icon-crop",
@@ -15909,6 +17897,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "css3",
     "tags": "brand, logo",
     "class": "icomoon icon-css3",
@@ -15917,6 +17906,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "dashboard",
     "tags": "speedometer, tachometer",
     "class": "icomoon icon-dashboard",
@@ -15925,6 +17915,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "delicious",
     "tags": "brand, logo, social",
     "class": "icomoon icon-delicious",
@@ -15933,6 +17924,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "deviantart",
     "tags": "brand, logo, social",
     "class": "icomoon icon-deviantart",
@@ -15941,6 +17933,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "deviantart-2",
     "tags": "brand, logo, social",
     "class": "icomoon icon-deviantart-2",
@@ -15949,6 +17942,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "diamonds",
     "tags": "cards",
     "class": "icomoon icon-diamonds",
@@ -15957,6 +17951,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "dice",
     "tags": "games",
     "class": "icomoon icon-dice",
@@ -15965,6 +17960,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "disk",
     "tags": "floppy, save",
     "class": "icomoon icon-disk",
@@ -15973,6 +17969,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "download",
     "tags": "",
     "class": "icomoon icon-download",
@@ -15981,6 +17978,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "download-2",
     "tags": "",
     "class": "icomoon icon-download-2",
@@ -15989,6 +17987,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "download-3",
     "tags": "",
     "class": "icomoon icon-download-3",
@@ -15997,6 +17996,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "drawer",
     "tags": "email, inbox",
     "class": "icomoon icon-drawer",
@@ -16005,6 +18005,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "drawer-2",
     "tags": "email, inbox",
     "class": "icomoon icon-drawer-2",
@@ -16013,6 +18014,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "drawer-3",
     "tags": "email, inbox",
     "class": "icomoon icon-drawer-3",
@@ -16021,6 +18023,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "dribbble",
     "tags": "brand, logo, social",
     "class": "icomoon icon-dribbble",
@@ -16029,6 +18032,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "dribbble-2",
     "tags": "brand, logo, social",
     "class": "icomoon icon-dribbble-2",
@@ -16037,6 +18041,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "dribbble-3",
     "tags": "brand, logo, social",
     "class": "icomoon icon-dribbble-3",
@@ -16045,6 +18050,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "droplet",
     "tags": "waterdrop",
     "class": "icomoon icon-droplet",
@@ -16053,6 +18059,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "earth",
     "tags": "globe, planet",
     "class": "icomoon icon-earth",
@@ -16061,6 +18068,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "eject",
     "tags": "",
     "class": "icomoon icon-eject",
@@ -16069,6 +18077,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "embed",
     "tags": "brackets, code",
     "class": "icomoon icon-embed",
@@ -16077,6 +18086,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "enter",
     "tags": "doorway",
     "class": "icomoon icon-enter",
@@ -16085,6 +18095,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "envelop",
     "tags": "mail",
     "class": "icomoon icon-envelop",
@@ -16093,6 +18104,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "equalizer",
     "tags": "levels, settings",
     "class": "icomoon icon-equalizer",
@@ -16101,6 +18113,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "evil",
     "tags": "devil, smiley face",
     "class": "icomoon icon-evil",
@@ -16109,6 +18122,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "evil-2",
     "tags": "devil, smiley face",
     "class": "icomoon icon-evil-2",
@@ -16117,6 +18131,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "exit",
     "tags": "doorway",
     "class": "icomoon icon-exit",
@@ -16125,6 +18140,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "expand",
     "tags": "resize",
     "class": "icomoon icon-expand",
@@ -16133,6 +18149,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "expand-2",
     "tags": "resize",
     "class": "icomoon icon-expand-2",
@@ -16141,6 +18158,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "eye-blocked",
     "tags": "hide",
     "class": "icomoon icon-eye-blocked",
@@ -16149,6 +18167,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "eye",
     "tags": "display, show",
     "class": "icomoon icon-eye",
@@ -16157,6 +18176,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "eye-2",
     "tags": "display, show",
     "class": "icomoon icon-eye-2",
@@ -16165,6 +18185,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "facebook",
     "tags": "brand, logo, social",
     "class": "icomoon icon-facebook",
@@ -16173,6 +18194,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "facebook-2",
     "tags": "brand, logo, social",
     "class": "icomoon icon-facebook-2",
@@ -16181,6 +18203,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "facebook-3",
     "tags": "brand, logo, social",
     "class": "icomoon icon-facebook-3",
@@ -16189,6 +18212,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "feed",
     "tags": "rss",
     "class": "icomoon icon-feed",
@@ -16197,6 +18221,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "feed-2",
     "tags": "rss",
     "class": "icomoon icon-feed-2",
@@ -16205,6 +18230,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "feed-3",
     "tags": "rss",
     "class": "icomoon icon-feed-3",
@@ -16213,6 +18239,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "feed-4",
     "tags": "rss",
     "class": "icomoon icon-feed-4",
@@ -16221,6 +18248,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "file-css",
     "tags": "document",
     "class": "icomoon icon-file-css",
@@ -16229,6 +18257,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "file-excel",
     "tags": "document",
     "class": "icomoon icon-file-excel",
@@ -16237,6 +18266,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "file-openoffice",
     "tags": "document",
     "class": "icomoon icon-file-openoffice",
@@ -16245,6 +18275,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "file-pdf",
     "tags": "document",
     "class": "icomoon icon-file-pdf",
@@ -16253,6 +18284,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "file-powerpoint",
     "tags": "document",
     "class": "icomoon icon-file-powerpoint",
@@ -16261,6 +18293,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "file-word",
     "tags": "document",
     "class": "icomoon icon-file-word",
@@ -16269,6 +18302,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "file-xml",
     "tags": "document",
     "class": "icomoon icon-file-xml",
@@ -16277,6 +18311,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "file-zip",
     "tags": "document",
     "class": "icomoon icon-file-zip",
@@ -16285,6 +18320,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "file",
     "tags": "document",
     "class": "icomoon icon-file",
@@ -16293,6 +18329,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "file-2",
     "tags": "document",
     "class": "icomoon icon-file-2",
@@ -16301,6 +18338,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "file-3",
     "tags": "document",
     "class": "icomoon icon-file-3",
@@ -16309,6 +18347,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "file-4",
     "tags": "document",
     "class": "icomoon icon-file-4",
@@ -16317,6 +18356,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "film",
     "tags": "movie, video",
     "class": "icomoon icon-film",
@@ -16325,6 +18365,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "filter",
     "tags": "",
     "class": "icomoon icon-filter",
@@ -16333,6 +18374,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "filter-2",
     "tags": "",
     "class": "icomoon icon-filter-2",
@@ -16341,6 +18383,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "finder",
     "tags": "apple, mac, logo",
     "class": "icomoon icon-finder",
@@ -16349,6 +18392,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "fire",
     "tags": "flame",
     "class": "icomoon icon-fire",
@@ -16357,6 +18401,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "firefox",
     "tags": "brand, browser, logo",
     "class": "icomoon icon-firefox",
@@ -16365,6 +18410,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "first",
     "tags": "video player",
     "class": "icomoon icon-first",
@@ -16373,6 +18419,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "flag",
     "tags": "brand, logo, social",
     "class": "icomoon icon-flag",
@@ -16381,6 +18428,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "flattr",
     "tags": "brand, logo, social",
     "class": "icomoon icon-flattr",
@@ -16389,6 +18437,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "flickr",
     "tags": "brand, logo, social",
     "class": "icomoon icon-flickr",
@@ -16397,6 +18446,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "flickr-2",
     "tags": "brand, logo, social",
     "class": "icomoon icon-flickr-2",
@@ -16405,6 +18455,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "flickr-3",
     "tags": "brand, logo, social",
     "class": "icomoon icon-flickr-3",
@@ -16413,6 +18464,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "flickr-4",
     "tags": "brand, logo, social",
     "class": "icomoon icon-flickr-4",
@@ -16421,6 +18473,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "flip",
     "tags": "",
     "class": "icomoon icon-flip",
@@ -16429,6 +18482,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "flip-2",
     "tags": "",
     "class": "icomoon icon-flip-2",
@@ -16437,6 +18491,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "folder-open",
     "tags": "",
     "class": "icomoon icon-folder-open",
@@ -16445,6 +18500,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "folder",
     "tags": "",
     "class": "icomoon icon-folder",
@@ -16453,6 +18509,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "font",
     "tags": "text editor",
     "class": "icomoon icon-font",
@@ -16461,6 +18518,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "food",
     "tags": "cutlery, dining, fork, knife",
     "class": "icomoon icon-food",
@@ -16469,6 +18527,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "forrst",
     "tags": "brand, logo, social",
     "class": "icomoon icon-forrst",
@@ -16477,6 +18536,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "forrst-2",
     "tags": "brand, logo, social",
     "class": "icomoon icon-forrst-2",
@@ -16485,6 +18545,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "forward",
     "tags": "arrow",
     "class": "icomoon icon-forward",
@@ -16493,6 +18554,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "forward-2",
     "tags": "video player, fast forward",
     "class": "icomoon icon-forward-2",
@@ -16501,6 +18563,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "forward-3",
     "tags": "video player, fast forward",
     "class": "icomoon icon-forward-3",
@@ -16509,6 +18572,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "foursquare",
     "tags": "brand, logo, social",
     "class": "icomoon icon-foursquare",
@@ -16517,6 +18581,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "foursquare-2",
     "tags": "brand, logo, social",
     "class": "icomoon icon-foursquare-2",
@@ -16525,6 +18590,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "gift",
     "tags": "present",
     "class": "icomoon icon-gift",
@@ -16533,6 +18599,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "github",
     "tags": "brand, logo, social",
     "class": "icomoon icon-github",
@@ -16541,6 +18608,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "github-2",
     "tags": "brand, logo, social",
     "class": "icomoon icon-github-2",
@@ -16549,6 +18617,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "github-3",
     "tags": "brand, logo, social",
     "class": "icomoon icon-github-3",
@@ -16557,6 +18626,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "github-4",
     "tags": "brand, logo, social",
     "class": "icomoon icon-github-4",
@@ -16565,6 +18635,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "github-5",
     "tags": "brand, logo, social",
     "class": "icomoon icon-github-5",
@@ -16573,6 +18644,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "glass",
     "tags": "drink, martini, alcohol, cocktail",
     "class": "icomoon icon-glass",
@@ -16581,6 +18653,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "globe",
     "tags": "earth, planet",
     "class": "icomoon icon-globe",
@@ -16589,6 +18662,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "google-drive",
     "tags": "brand, logo, social",
     "class": "icomoon icon-google-drive",
@@ -16597,6 +18671,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "google-plus",
     "tags": "brand, logo, social",
     "class": "icomoon icon-google-plus",
@@ -16605,6 +18680,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "google-plus-2",
     "tags": "brand, logo, social",
     "class": "icomoon icon-google-plus-2",
@@ -16613,6 +18689,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "google-plus-3",
     "tags": "brand, logo, social",
     "class": "icomoon icon-google-plus-3",
@@ -16621,6 +18698,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "google-plus-4",
     "tags": "brand, logo, social",
     "class": "icomoon icon-google-plus-4",
@@ -16629,6 +18707,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "google",
     "tags": "brand, logo, social",
     "class": "icomoon icon-google",
@@ -16637,6 +18716,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "grin",
     "tags": "smiley face",
     "class": "icomoon icon-grin",
@@ -16645,6 +18725,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "grin-2",
     "tags": "smiley face",
     "class": "icomoon icon-grin-2",
@@ -16653,6 +18734,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "hammer",
     "tags": "tool",
     "class": "icomoon icon-hammer",
@@ -16661,6 +18743,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "hammer-2",
     "tags": "gavel, tool",
     "class": "icomoon icon-hammer-2",
@@ -16669,6 +18752,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "happy",
     "tags": "smiley face",
     "class": "icomoon icon-happy",
@@ -16677,6 +18761,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "happy-2",
     "tags": "smiley face",
     "class": "icomoon icon-happy-2",
@@ -16685,6 +18770,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "headphones",
     "tags": "audio, music",
     "class": "icomoon icon-headphones",
@@ -16693,6 +18779,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "heart-broken",
     "tags": "sad",
     "class": "icomoon icon-heart-broken",
@@ -16701,6 +18788,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "heart",
     "tags": "like, love",
     "class": "icomoon icon-heart",
@@ -16709,6 +18797,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "heart-2",
     "tags": "like, love",
     "class": "icomoon icon-heart-2",
@@ -16717,6 +18806,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "history",
     "tags": "",
     "class": "icomoon icon-history",
@@ -16725,6 +18815,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "home",
     "tags": "house",
     "class": "icomoon icon-home",
@@ -16733,6 +18824,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "home-2",
     "tags": "house",
     "class": "icomoon icon-home-2",
@@ -16741,6 +18833,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "home-3",
     "tags": "house",
     "class": "icomoon icon-home-3",
@@ -16749,6 +18842,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "html5",
     "tags": "brand, web",
     "class": "icomoon icon-html5",
@@ -16757,6 +18851,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "html5-2",
     "tags": "brand, web",
     "class": "icomoon icon-html5-2",
@@ -16765,6 +18860,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "IcoMoon",
     "tags": "brand",
     "class": "icomoon icon-IcoMoon",
@@ -16773,6 +18869,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "IE",
     "tags": "brand, browser, logo",
     "class": "icomoon icon-IE",
@@ -16781,6 +18878,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "image",
     "tags": "picture",
     "class": "icomoon icon-image",
@@ -16789,6 +18887,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "image-2",
     "tags": "picture",
     "class": "icomoon icon-image-2",
@@ -16797,6 +18896,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "images",
     "tags": "pictures",
     "class": "icomoon icon-images",
@@ -16805,6 +18905,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "indent-decrease",
     "tags": "text editor",
     "class": "icomoon icon-indent-decrease",
@@ -16813,6 +18914,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "indent-increase",
     "tags": "text editor",
     "class": "icomoon icon-indent-increase",
@@ -16821,6 +18923,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "info",
     "tags": "",
     "class": "icomoon icon-info",
@@ -16829,6 +18932,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "info-2",
     "tags": "",
     "class": "icomoon icon-info-2",
@@ -16837,6 +18941,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "insert-template",
     "tags": "",
     "class": "icomoon icon-insert-template",
@@ -16845,6 +18950,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "instagram",
     "tags": "brand, logo, social",
     "class": "icomoon icon-instagram",
@@ -16853,6 +18959,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "italic",
     "tags": "text editor",
     "class": "icomoon icon-italic",
@@ -16861,6 +18968,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "joomla",
     "tags": "brand, logo",
     "class": "icomoon icon-joomla",
@@ -16869,6 +18977,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "key",
     "tags": "lock",
     "class": "icomoon icon-key",
@@ -16877,6 +18986,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "key-2",
     "tags": "lock",
     "class": "icomoon icon-key-2",
@@ -16885,6 +18995,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "keyboard",
     "tags": "",
     "class": "icomoon icon-keyboard",
@@ -16893,6 +19004,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "lab",
     "tags": "beaker, flask, science",
     "class": "icomoon icon-lab",
@@ -16901,6 +19013,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "lanyrd",
     "tags": "brand, logo, social",
     "class": "icomoon icon-lanyrd",
@@ -16909,6 +19022,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "laptop",
     "tags": "computer",
     "class": "icomoon icon-laptop",
@@ -16917,6 +19031,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "last",
     "tags": "fast forward",
     "class": "icomoon icon-last",
@@ -16925,6 +19040,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "lastfm",
     "tags": "brand, logo, social",
     "class": "icomoon icon-lastfm",
@@ -16933,6 +19049,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "lastfm-2",
     "tags": "brand, logo, social",
     "class": "icomoon icon-lastfm-2",
@@ -16941,6 +19058,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "leaf",
     "tags": "",
     "class": "icomoon icon-leaf",
@@ -16949,6 +19067,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "left-to-right",
     "tags": "paragraph, text editor",
     "class": "icomoon icon-left-to-right",
@@ -16957,6 +19076,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "library",
     "tags": "building",
     "class": "icomoon icon-library",
@@ -16965,6 +19085,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "libreoffice",
     "tags": "brandlogo, ",
     "class": "icomoon icon-libreoffice",
@@ -16973,6 +19094,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "lightning",
     "tags": "bolt",
     "class": "icomoon icon-lightning",
@@ -16981,6 +19103,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "link",
     "tags": "chain",
     "class": "icomoon icon-link",
@@ -16989,6 +19112,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "linkedin",
     "tags": "brand, logo, social",
     "class": "icomoon icon-linkedin",
@@ -16997,6 +19121,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "list",
     "tags": "",
     "class": "icomoon icon-list",
@@ -17005,6 +19130,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "list-2",
     "tags": "",
     "class": "icomoon icon-list-2",
@@ -17013,6 +19139,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "location",
     "tags": "map marker",
     "class": "icomoon icon-location",
@@ -17021,6 +19148,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "location-2",
     "tags": "map marker",
     "class": "icomoon icon-location-2",
@@ -17029,6 +19157,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "lock",
     "tags": "padlock",
     "class": "icomoon icon-lock",
@@ -17037,6 +19166,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "lock-2",
     "tags": "padlock",
     "class": "icomoon icon-lock-2",
@@ -17045,6 +19175,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "loop",
     "tags": "repeat, refresh",
     "class": "icomoon icon-loop",
@@ -17053,6 +19184,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "loop-2",
     "tags": "repeat, refresh",
     "class": "icomoon icon-loop-2",
@@ -17061,6 +19193,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "loop-3",
     "tags": "repeat, refresh",
     "class": "icomoon icon-loop-3",
@@ -17069,6 +19202,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "magnet",
     "tags": "",
     "class": "icomoon icon-magnet",
@@ -17077,6 +19211,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "mail",
     "tags": "envelope",
     "class": "icomoon icon-mail",
@@ -17085,6 +19220,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "mail-2",
     "tags": "envelope",
     "class": "icomoon icon-mail-2",
@@ -17093,6 +19229,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "mail-3",
     "tags": "envelope",
     "class": "icomoon icon-mail-3",
@@ -17101,6 +19238,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "mail-4",
     "tags": "envelope",
     "class": "icomoon icon-mail-4",
@@ -17109,6 +19247,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "map",
     "tags": "",
     "class": "icomoon icon-map",
@@ -17117,6 +19256,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "map-2",
     "tags": "",
     "class": "icomoon icon-map-2",
@@ -17125,6 +19265,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "menu",
     "tags": "bars, drag, reorder",
     "class": "icomoon icon-menu",
@@ -17133,6 +19274,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "menu-2",
     "tags": "bars, hamburger menu, more",
     "class": "icomoon icon-menu-2",
@@ -17141,6 +19283,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "meter",
     "tags": "dashboard, gauge, speedometer",
     "class": "icomoon icon-meter",
@@ -17149,6 +19292,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "meter2",
     "tags": "dashboard, gauge, speedometer",
     "class": "icomoon icon-meter2",
@@ -17157,6 +19301,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "minus",
     "tags": "",
     "class": "icomoon icon-minus",
@@ -17165,6 +19310,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "mobile",
     "tags": "phone",
     "class": "icomoon icon-mobile",
@@ -17173,6 +19319,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "mobile-2",
     "tags": "phone",
     "class": "icomoon icon-mobile-2",
@@ -17181,6 +19328,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "mug",
     "tags": "coffee, cup, drink",
     "class": "icomoon icon-mug",
@@ -17189,6 +19337,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "music",
     "tags": "audio",
     "class": "icomoon icon-music",
@@ -17197,6 +19346,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "neutral",
     "tags": "smiley face",
     "class": "icomoon icon-neutral",
@@ -17205,6 +19355,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "neutral-2",
     "tags": "smiley face",
     "class": "icomoon icon-neutral-2",
@@ -17213,6 +19364,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "new-tab",
     "tags": "",
     "class": "icomoon icon-new-tab",
@@ -17221,6 +19373,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "newspaper",
     "tags": "",
     "class": "icomoon icon-newspaper",
@@ -17229,6 +19382,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "next",
     "tags": "skip",
     "class": "icomoon icon-next",
@@ -17237,6 +19391,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "notebook",
     "tags": "",
     "class": "icomoon icon-notebook",
@@ -17245,6 +19400,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "notification",
     "tags": "",
     "class": "icomoon icon-notification",
@@ -17253,6 +19409,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "numbered-list",
     "tags": "",
     "class": "icomoon icon-numbered-list",
@@ -17261,6 +19418,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "office",
     "tags": "buildings",
     "class": "icomoon icon-office",
@@ -17269,6 +19427,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "omega",
     "tags": "greek letter",
     "class": "icomoon icon-omega",
@@ -17277,6 +19436,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "opera",
     "tags": "brand, browser, logo",
     "class": "icomoon icon-opera",
@@ -17285,6 +19445,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "pacman",
     "tags": "game",
     "class": "icomoon icon-pacman",
@@ -17293,6 +19454,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "paint-format",
     "tags": "",
     "class": "icomoon icon-paint-format",
@@ -17301,6 +19463,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "paragraph-center",
     "tags": "text editor",
     "class": "icomoon icon-paragraph-center",
@@ -17309,6 +19472,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "paragraph-center-2",
     "tags": "text editor",
     "class": "icomoon icon-paragraph-center-2",
@@ -17317,6 +19481,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "paragraph-justify",
     "tags": "text editor",
     "class": "icomoon icon-paragraph-justify",
@@ -17325,6 +19490,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "paragraph-justify-2",
     "tags": "text editor",
     "class": "icomoon icon-paragraph-justify-2",
@@ -17333,6 +19499,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "paragraph-left",
     "tags": "text editor",
     "class": "icomoon icon-paragraph-left",
@@ -17341,6 +19508,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "paragraph-left-2",
     "tags": "text editor",
     "class": "icomoon icon-paragraph-left-2",
@@ -17349,6 +19517,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "paragraph-right",
     "tags": "text editor",
     "class": "icomoon icon-paragraph-right",
@@ -17357,6 +19526,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "paragraph-right-2",
     "tags": "text editor",
     "class": "icomoon icon-paragraph-right-2",
@@ -17365,6 +19535,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "paste",
     "tags": "clipboard",
     "class": "icomoon icon-paste",
@@ -17373,6 +19544,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "paste-2",
     "tags": "clipboard",
     "class": "icomoon icon-paste-2",
@@ -17381,6 +19553,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "paste-3",
     "tags": "clipboard",
     "class": "icomoon icon-paste-3",
@@ -17389,6 +19562,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "pause",
     "tags": "video player",
     "class": "icomoon icon-pause",
@@ -17397,6 +19571,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "pause-2",
     "tags": "video player",
     "class": "icomoon icon-pause-2",
@@ -17405,6 +19580,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "pawn",
     "tags": "chess, game",
     "class": "icomoon icon-pawn",
@@ -17413,6 +19589,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "paypal",
     "tags": "brand, logo, payment, social",
     "class": "icomoon icon-paypal",
@@ -17421,6 +19598,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "paypal-2",
     "tags": "brand, logo, payment, social",
     "class": "icomoon icon-paypal-2",
@@ -17429,6 +19607,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "paypal-3",
     "tags": "brand, logo, payment, social",
     "class": "icomoon icon-paypal-3",
@@ -17437,6 +19616,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "pen",
     "tags": "write",
     "class": "icomoon icon-pen",
@@ -17445,6 +19625,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "pencil",
     "tags": "write",
     "class": "icomoon icon-pencil",
@@ -17453,6 +19634,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "pencil-2",
     "tags": "write",
     "class": "icomoon icon-pencil-2",
@@ -17461,6 +19643,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "phone-hang-up",
     "tags": "",
     "class": "icomoon icon-phone-hang-up",
@@ -17469,6 +19652,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "phone",
     "tags": "",
     "class": "icomoon icon-phone",
@@ -17477,6 +19661,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "picassa",
     "tags": "brand, logo, social",
     "class": "icomoon icon-picassa",
@@ -17485,6 +19670,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "picassa-2",
     "tags": "brand, logo, social",
     "class": "icomoon icon-picassa-2",
@@ -17493,6 +19679,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "pie",
     "tags": "chart, graph",
     "class": "icomoon icon-pie",
@@ -17501,6 +19688,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "pilcrow",
     "tags": "paragraph, text editor",
     "class": "icomoon icon-pilcrow",
@@ -17509,6 +19697,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "pinterest",
     "tags": "brand, logo, social",
     "class": "icomoon icon-pinterest",
@@ -17517,6 +19706,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "pinterest-2",
     "tags": "brand, logo, social",
     "class": "icomoon icon-pinterest-2",
@@ -17525,6 +19715,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "play",
     "tags": "video player",
     "class": "icomoon icon-play",
@@ -17533,6 +19724,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "play-2",
     "tags": "video player",
     "class": "icomoon icon-play-2",
@@ -17541,6 +19733,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "play-3",
     "tags": "video player",
     "class": "icomoon icon-play-3",
@@ -17549,6 +19742,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "plus",
     "tags": "add",
     "class": "icomoon icon-plus",
@@ -17557,6 +19751,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "podcast",
     "tags": "broadcast, social",
     "class": "icomoon icon-podcast",
@@ -17565,6 +19760,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "point-down",
     "tags": "directional, finger, hand",
     "class": "icomoon icon-point-down",
@@ -17573,6 +19769,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "point-left",
     "tags": "directional, finger, hand",
     "class": "icomoon icon-point-left",
@@ -17581,6 +19778,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "point-right",
     "tags": "directional, finger, hand",
     "class": "icomoon icon-point-right",
@@ -17589,6 +19787,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "point-up",
     "tags": "directional, finger, hand",
     "class": "icomoon icon-point-up",
@@ -17597,6 +19796,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "power-cord",
     "tags": "plug",
     "class": "icomoon icon-power-cord",
@@ -17605,6 +19805,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "previous",
     "tags": "video player",
     "class": "icomoon icon-previous",
@@ -17613,6 +19814,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "print",
     "tags": "",
     "class": "icomoon icon-print",
@@ -17621,6 +19823,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "profile",
     "tags": "",
     "class": "icomoon icon-profile",
@@ -17629,6 +19832,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "pushpin",
     "tags": "",
     "class": "icomoon icon-pushpin",
@@ -17637,6 +19841,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "qrcode",
     "tags": "",
     "class": "icomoon icon-qrcode",
@@ -17645,6 +19850,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "question",
     "tags": "help, mark",
     "class": "icomoon icon-question",
@@ -17653,6 +19859,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "quill",
     "tags": "feather, pen",
     "class": "icomoon icon-quill",
@@ -17661,6 +19868,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "quotes-left",
     "tags": "text editor",
     "class": "icomoon icon-quotes-left",
@@ -17669,6 +19877,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "radio-checked",
     "tags": "form controls",
     "class": "icomoon icon-radio-checked",
@@ -17677,6 +19886,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "radio-unchecked",
     "tags": "form controls",
     "class": "icomoon icon-radio-unchecked",
@@ -17685,6 +19895,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "reddit",
     "tags": "alien, brand, logo, social",
     "class": "icomoon icon-reddit",
@@ -17693,6 +19904,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "redo",
     "tags": "text editor",
     "class": "icomoon icon-redo",
@@ -17701,6 +19913,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "redo-2",
     "tags": "text editor",
     "class": "icomoon icon-redo-2",
@@ -17709,6 +19922,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "remove",
     "tags": "delete, trashcan",
     "class": "icomoon icon-remove",
@@ -17717,6 +19931,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "remove-2",
     "tags": "delete, trashcan",
     "class": "icomoon icon-remove-2",
@@ -17725,6 +19940,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "reply",
     "tags": "email",
     "class": "icomoon icon-reply",
@@ -17733,6 +19949,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "right-to-left",
     "tags": "text editor",
     "class": "icomoon icon-right-to-left",
@@ -17741,6 +19958,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "road",
     "tags": "",
     "class": "icomoon icon-road",
@@ -17749,6 +19967,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "rocket",
     "tags": "spaceship",
     "class": "icomoon icon-rocket",
@@ -17757,6 +19976,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "sad",
     "tags": "frown, smiley face",
     "class": "icomoon icon-sad",
@@ -17765,6 +19985,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "sad-2",
     "tags": "frown, smiley face",
     "class": "icomoon icon-sad-2",
@@ -17773,6 +19994,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "safari",
     "tags": "brand, browser, compass, logo",
     "class": "icomoon icon-safari",
@@ -17781,6 +20003,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "scissors",
     "tags": "cut, clipboard",
     "class": "icomoon icon-scissors",
@@ -17789,6 +20012,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "screen",
     "tags": "computer, monitor",
     "class": "icomoon icon-screen",
@@ -17797,6 +20021,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "search",
     "tags": "find, magnifying glass",
     "class": "icomoon icon-search",
@@ -17805,6 +20030,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "settings",
     "tags": "",
     "class": "icomoon icon-settings",
@@ -17813,6 +20039,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "share",
     "tags": "social",
     "class": "icomoon icon-share",
@@ -17821,6 +20048,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "shield",
     "tags": "",
     "class": "icomoon icon-shield",
@@ -17829,6 +20057,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "shocked",
     "tags": "smiley face",
     "class": "icomoon icon-shocked",
@@ -17837,6 +20066,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "shocked-2",
     "tags": "smiley face",
     "class": "icomoon icon-shocked-2",
@@ -17845,6 +20075,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "shuffle",
     "tags": "random, video player",
     "class": "icomoon icon-shuffle",
@@ -17853,6 +20084,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "sigma",
     "tags": "greek letter",
     "class": "icomoon icon-sigma",
@@ -17861,6 +20093,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "signup",
     "tags": "clipboard, checkmark",
     "class": "icomoon icon-signup",
@@ -17869,6 +20102,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "skype",
     "tags": "brand, logo, social",
     "class": "icomoon icon-skype",
@@ -17877,6 +20111,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "smiley",
     "tags": "face",
     "class": "icomoon icon-smiley",
@@ -17885,6 +20120,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "smiley-2",
     "tags": "face",
     "class": "icomoon icon-smiley-2",
@@ -17893,6 +20129,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "soundcloud",
     "tags": "brand, logo, social",
     "class": "icomoon icon-soundcloud",
@@ -17901,6 +20138,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "soundcloud-2",
     "tags": "brand, logo, social",
     "class": "icomoon icon-soundcloud-2",
@@ -17909,6 +20147,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "spades",
     "tags": "cards",
     "class": "icomoon icon-spades",
@@ -17917,6 +20156,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "spam",
     "tags": "caution, danger, exclamation point, sign, warning",
     "class": "icomoon icon-spam",
@@ -17925,6 +20165,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "spell-check",
     "tags": "text editor",
     "class": "icomoon icon-spell-check",
@@ -17933,6 +20174,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "spinner",
     "tags": "loading",
     "class": "icomoon icon-spinner",
@@ -17941,6 +20183,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "spinner-2",
     "tags": "loading",
     "class": "icomoon icon-spinner-2",
@@ -17949,6 +20192,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "spinner-3",
     "tags": "loading",
     "class": "icomoon icon-spinner-3",
@@ -17957,6 +20201,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "spinner-4",
     "tags": "",
     "class": "icomoon icon-spinner-4",
@@ -17965,6 +20210,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "spinner-5",
     "tags": "loading",
     "class": "icomoon icon-spinner-5",
@@ -17973,6 +20219,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "spinner-6",
     "tags": "loading",
     "class": "icomoon icon-spinner-6",
@@ -17981,6 +20228,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "stack",
     "tags": "",
     "class": "icomoon icon-stack",
@@ -17989,6 +20237,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "stackoverflow",
     "tags": "brand, logo, social",
     "class": "icomoon icon-stackoverflow",
@@ -17997,6 +20246,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "star",
     "tags": "like, ratings",
     "class": "icomoon icon-star",
@@ -18005,6 +20255,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "star-2",
     "tags": "like, ratings",
     "class": "icomoon icon-star-2",
@@ -18013,6 +20264,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "star-3",
     "tags": "like, ratings",
     "class": "icomoon icon-star-3",
@@ -18021,6 +20273,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "stats",
     "tags": "chart, graph",
     "class": "icomoon icon-stats",
@@ -18029,6 +20282,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "steam",
     "tags": "brand, logo, game, social",
     "class": "icomoon icon-steam",
@@ -18037,6 +20291,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "steam-2",
     "tags": "brand, logo, game, social",
     "class": "icomoon icon-steam-2",
@@ -18045,6 +20300,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "stop",
     "tags": "square, video player",
     "class": "icomoon icon-stop",
@@ -18053,6 +20309,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "stop-2",
     "tags": "square, video player",
     "class": "icomoon icon-stop-2",
@@ -18061,6 +20318,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "stopwatch",
     "tags": "clock, timer",
     "class": "icomoon icon-stopwatch",
@@ -18069,6 +20327,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "storage",
     "tags": "disk, hard drive",
     "class": "icomoon icon-storage",
@@ -18077,6 +20336,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "strikethrough",
     "tags": "text editor",
     "class": "icomoon icon-strikethrough",
@@ -18085,6 +20345,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "stumbleupon",
     "tags": "brand, logo, social",
     "class": "icomoon icon-stumbleupon",
@@ -18093,6 +20354,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "stumbleupon-2",
     "tags": "brand, logo, social",
     "class": "icomoon icon-stumbleupon-2",
@@ -18101,6 +20363,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "support",
     "tags": "help, buoy, lifesaver",
     "class": "icomoon icon-support",
@@ -18109,6 +20372,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "switch",
     "tags": "on, power",
     "class": "icomoon icon-switch",
@@ -18117,6 +20381,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "tab",
     "tags": "text editor",
     "class": "icomoon icon-tab",
@@ -18125,6 +20390,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "table",
     "tags": "chart",
     "class": "icomoon icon-table",
@@ -18133,6 +20399,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "table-2",
     "tags": "chart",
     "class": "icomoon icon-table-2",
@@ -18141,6 +20408,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "tablet",
     "tags": "computer, ipad",
     "class": "icomoon icon-tablet",
@@ -18149,6 +20417,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "tag",
     "tags": "pricetag, shopping",
     "class": "icomoon icon-tag",
@@ -18157,6 +20426,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "tags",
     "tags": "pricetags, shopping",
     "class": "icomoon icon-tags",
@@ -18165,6 +20435,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "target",
     "tags": "aim, reticle",
     "class": "icomoon icon-target",
@@ -18173,6 +20444,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "text-height",
     "tags": "text editor",
     "class": "icomoon icon-text-height",
@@ -18181,6 +20453,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "text-width",
     "tags": "text editor",
     "class": "icomoon icon-text-width",
@@ -18189,6 +20462,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "thumbs-up",
     "tags": "like, ratings",
     "class": "icomoon icon-thumbs-up",
@@ -18197,6 +20471,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "thumbs-up-2",
     "tags": "dislike, ratings",
     "class": "icomoon icon-thumbs-up-2",
@@ -18205,6 +20480,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "ticket",
     "tags": "film, movie, admission",
     "class": "icomoon icon-ticket",
@@ -18213,6 +20489,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "tongue",
     "tags": "smiley face",
     "class": "icomoon icon-tongue",
@@ -18221,6 +20498,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "tongue-2",
     "tags": "smiley face",
     "class": "icomoon icon-tongue-2",
@@ -18229,6 +20507,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "tree",
     "tags": "graph",
     "class": "icomoon icon-tree",
@@ -18237,6 +20516,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "trophy",
     "tags": "award, prize",
     "class": "icomoon icon-trophy",
@@ -18245,6 +20525,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "truck",
     "tags": "vehicle",
     "class": "icomoon icon-truck",
@@ -18253,6 +20534,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "tumblr",
     "tags": "brand, logo, social",
     "class": "icomoon icon-tumblr",
@@ -18261,6 +20543,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "tumblr-2",
     "tags": "brand, logo, social",
     "class": "icomoon icon-tumblr-2",
@@ -18269,6 +20552,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "tux",
     "tags": "bird, brand, logo, penguin",
     "class": "icomoon icon-tux",
@@ -18277,6 +20561,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "tv",
     "tags": "television",
     "class": "icomoon icon-tv",
@@ -18285,6 +20570,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "twitter",
     "tags": "brand, bird, logo, social",
     "class": "icomoon icon-twitter",
@@ -18293,6 +20579,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "twitter-2",
     "tags": "brand, bird, logo, social",
     "class": "icomoon icon-twitter-2",
@@ -18301,6 +20588,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "twitter-3",
     "tags": "brand, bird, logo, social",
     "class": "icomoon icon-twitter-3",
@@ -18309,6 +20597,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "underline",
     "tags": "text editor",
     "class": "icomoon icon-underline",
@@ -18317,6 +20606,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "undo",
     "tags": "arrow, text editor",
     "class": "icomoon icon-undo",
@@ -18325,6 +20615,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "undo-2",
     "tags": "arrow, text editor",
     "class": "icomoon icon-undo-2",
@@ -18333,6 +20624,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "unlocked",
     "tags": "padlock",
     "class": "icomoon icon-unlocked",
@@ -18341,6 +20633,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "upload",
     "tags": "",
     "class": "icomoon icon-upload",
@@ -18349,6 +20642,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "upload-2",
     "tags": "",
     "class": "icomoon icon-upload-2",
@@ -18357,6 +20651,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "upload-3",
     "tags": "",
     "class": "icomoon icon-upload-3",
@@ -18365,6 +20660,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "user",
     "tags": "person",
     "class": "icomoon icon-user",
@@ -18373,6 +20669,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "user-2",
     "tags": "person",
     "class": "icomoon icon-user-2",
@@ -18381,6 +20678,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "user-3",
     "tags": "person",
     "class": "icomoon icon-user-3",
@@ -18389,6 +20687,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "user-4",
     "tags": "person",
     "class": "icomoon icon-user-4",
@@ -18397,6 +20696,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "users",
     "tags": "people",
     "class": "icomoon icon-users",
@@ -18405,6 +20705,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "users-2",
     "tags": "people",
     "class": "icomoon icon-users-2",
@@ -18413,6 +20714,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "vimeo",
     "tags": "brand, social, logo",
     "class": "icomoon icon-vimeo",
@@ -18421,6 +20723,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "vimeo-2",
     "tags": "brand, social, logo",
     "class": "icomoon icon-vimeo-2",
@@ -18429,6 +20732,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "vimeo2",
     "tags": "brand, social, logo",
     "class": "icomoon icon-vimeo2",
@@ -18437,6 +20741,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "volume-decrease",
     "tags": "audio, sound",
     "class": "icomoon icon-volume-decrease",
@@ -18445,6 +20750,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "volume-high",
     "tags": "audio, sound",
     "class": "icomoon icon-volume-high",
@@ -18453,6 +20759,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "volume-increase",
     "tags": "audio, sound",
     "class": "icomoon icon-volume-increase",
@@ -18461,6 +20768,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "volume-low",
     "tags": "audio, sound",
     "class": "icomoon icon-volume-low",
@@ -18469,6 +20777,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "volume-medium",
     "tags": "audio, sound",
     "class": "icomoon icon-volume-medium",
@@ -18477,6 +20786,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "volume-mute",
     "tags": "audio, sound",
     "class": "icomoon icon-volume-mute",
@@ -18485,6 +20795,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "volume-mute-2",
     "tags": "audio, sound",
     "class": "icomoon icon-volume-mute-2",
@@ -18493,6 +20804,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "wand",
     "tags": "magic",
     "class": "icomoon icon-wand",
@@ -18501,6 +20813,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "warning",
     "tags": "alert, caution, exclamation, sign",
     "class": "icomoon icon-warning",
@@ -18509,6 +20822,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "windows",
     "tags": "brand, logo",
     "class": "icomoon icon-windows",
@@ -18517,6 +20831,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "windows8",
     "tags": "brand, logo",
     "class": "icomoon icon-windows8",
@@ -18525,6 +20840,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "wink",
     "tags": "smiley face",
     "class": "icomoon icon-wink",
@@ -18533,6 +20849,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "wink-2",
     "tags": "smiley face",
     "class": "icomoon icon-wink-2",
@@ -18541,6 +20858,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "wondering",
     "tags": "smiley face",
     "class": "icomoon icon-wondering",
@@ -18549,6 +20867,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "wondering-2",
     "tags": "smiley face",
     "class": "icomoon icon-wondering-2",
@@ -18557,6 +20876,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "wordpress",
     "tags": "brand, blog, logo, social",
     "class": "icomoon icon-wordpress",
@@ -18565,6 +20885,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "wordpress-2",
     "tags": "brand, blog, logo, social",
     "class": "icomoon icon-wordpress-2",
@@ -18573,6 +20894,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "wrench",
     "tags": "settings, tool",
     "class": "icomoon icon-wrench",
@@ -18581,6 +20903,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "xing",
     "tags": "brand, logo, social",
     "class": "icomoon icon-xing",
@@ -18589,6 +20912,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "xing-2",
     "tags": "brand, logo, social",
     "class": "icomoon icon-xing-2",
@@ -18597,6 +20921,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "yahoo",
     "tags": "brand, logo, social",
     "class": "icomoon icon-yahoo",
@@ -18605,6 +20930,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "yelp",
     "tags": "brand, logo, social",
     "class": "icomoon icon-yelp",
@@ -18613,6 +20939,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "youtube",
     "tags": "brand, logo, social, video",
     "class": "icomoon icon-youtube",
@@ -18621,6 +20948,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "youtube-2",
     "tags": "brand, logo, social, video",
     "class": "icomoon icon-youtube-2",
@@ -18629,6 +20957,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "zoom-in",
     "tags": "magnifying glass",
     "class": "icomoon icon-zoom-in",
@@ -18637,6 +20966,7 @@
   },
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "zoom-out",
     "tags": "magnifying glass",
     "class": "icomoon icon-zoom-out",
@@ -18646,6 +20976,7 @@
 
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "3d_rotation",
     "tags": "",
     "class": "material-icons",
@@ -18654,6 +20985,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "access_alarm",
     "tags": "clock, reminder",
     "class": "material-icons",
@@ -18662,6 +20994,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "access_alarms",
     "tags": "clock, reminder",
     "class": "material-icons",
@@ -18670,6 +21003,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "access_time",
     "tags": "clock, timer",
     "class": "material-icons",
@@ -18678,6 +21012,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "accessibility",
     "tags": "",
     "class": "material-icons",
@@ -18686,6 +21021,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "account_balance",
     "tags": "bank, building",
     "class": "material-icons",
@@ -18694,6 +21030,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "account_balance_wallet",
     "tags": "",
     "class": "material-icons",
@@ -18702,6 +21039,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "account_box",
     "tags": "avatar, user",
     "class": "material-icons",
@@ -18710,6 +21048,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "account_circle",
     "tags": "avatar, user",
     "class": "material-icons",
@@ -18718,6 +21057,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "adb",
     "tags": "android bot, brand, logo",
     "class": "material-icons",
@@ -18726,6 +21066,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "add",
     "tags": "plus",
     "class": "material-icons",
@@ -18734,6 +21075,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "add_alarm",
     "tags": "clock, reminder",
     "class": "material-icons",
@@ -18742,6 +21084,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "add_alert",
     "tags": "bell",
     "class": "material-icons",
@@ -18750,6 +21093,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "add_box",
     "tags": "plus",
     "class": "material-icons",
@@ -18758,6 +21102,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "add_circle",
     "tags": "plus",
     "class": "material-icons",
@@ -18766,6 +21111,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "add_circle_outline",
     "tags": "plus",
     "class": "material-icons",
@@ -18774,6 +21120,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "add_shopping_cart",
     "tags": "",
     "class": "material-icons",
@@ -18782,6 +21129,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "add_to_photos",
     "tags": "",
     "class": "material-icons",
@@ -18790,6 +21138,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "adjust",
     "tags": "",
     "class": "material-icons",
@@ -18798,6 +21147,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "airline_seat_flat",
     "tags": "bed",
     "class": "material-icons",
@@ -18806,6 +21156,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "airline_seat_flat_angled",
     "tags": "bed",
     "class": "material-icons",
@@ -18814,6 +21165,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "airline_seat_individual_suite",
     "tags": "bed",
     "class": "material-icons",
@@ -18822,6 +21174,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "airline_seat_legroom_extra",
     "tags": "",
     "class": "material-icons",
@@ -18830,6 +21183,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "airline_seat_legroom_normal",
     "tags": "",
     "class": "material-icons",
@@ -18838,6 +21192,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "airline_seat_legroom_reduced",
     "tags": "",
     "class": "material-icons",
@@ -18846,6 +21201,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "airline_seat_recline_extra",
     "tags": "",
     "class": "material-icons",
@@ -18854,6 +21210,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "airline_seat_recline_normal",
     "tags": "",
     "class": "material-icons",
@@ -18862,6 +21219,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "airplanemode_active",
     "tags": "jet",
     "class": "material-icons",
@@ -18870,6 +21228,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "airplanemode_inactive",
     "tags": "jet",
     "class": "material-icons",
@@ -18878,6 +21237,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "airplay",
     "tags": "video",
     "class": "material-icons",
@@ -18886,6 +21246,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "alarm",
     "tags": "clock",
     "class": "material-icons",
@@ -18894,6 +21255,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "alarm_add",
     "tags": "clock",
     "class": "material-icons",
@@ -18902,6 +21264,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "alarm_off",
     "tags": "clock",
     "class": "material-icons",
@@ -18910,6 +21273,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "alarm_on",
     "tags": "clock",
     "class": "material-icons",
@@ -18918,6 +21282,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "album",
     "tags": "music, record, vinyl",
     "class": "material-icons",
@@ -18926,6 +21291,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "android",
     "tags": "brand, logo",
     "class": "material-icons",
@@ -18934,6 +21300,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "announcement",
     "tags": "alert, speech bubble",
     "class": "material-icons",
@@ -18942,6 +21309,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "apps",
     "tags": "grid",
     "class": "material-icons",
@@ -18950,6 +21318,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "archive",
     "tags": "download, save",
     "class": "material-icons",
@@ -18958,6 +21327,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "arrow_back",
     "tags": "directional",
     "class": "material-icons",
@@ -18966,6 +21336,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "arrow_drop_down",
     "tags": "caret",
     "class": "material-icons",
@@ -18974,6 +21345,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "arrow_drop_down_circle",
     "tags": "caret",
     "class": "material-icons",
@@ -18982,6 +21354,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "arrow_drop_up",
     "tags": "caret",
     "class": "material-icons",
@@ -18990,6 +21363,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "arrow_forward",
     "tags": "directional",
     "class": "material-icons",
@@ -18998,6 +21372,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "aspect_ratio",
     "tags": "",
     "class": "material-icons",
@@ -19006,6 +21381,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "assessment",
     "tags": "chart, graph",
     "class": "material-icons",
@@ -19014,6 +21390,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "assignment",
     "tags": "clipboard",
     "class": "material-icons",
@@ -19022,6 +21399,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "assignment_ind",
     "tags": "clipboard",
     "class": "material-icons",
@@ -19030,6 +21408,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "assignment_late",
     "tags": "clipboard",
     "class": "material-icons",
@@ -19038,6 +21417,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "assignment_return",
     "tags": "clipboard",
     "class": "material-icons",
@@ -19046,6 +21426,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "assignment_returned",
     "tags": "clipboard",
     "class": "material-icons",
@@ -19054,6 +21435,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "assignment_turned_in",
     "tags": "clipboard",
     "class": "material-icons",
@@ -19062,6 +21444,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "assistant",
     "tags": "",
     "class": "material-icons",
@@ -19070,6 +21453,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "assistant_photo",
     "tags": "flag",
     "class": "material-icons",
@@ -19078,6 +21462,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "attach_file",
     "tags": "paperclip",
     "class": "material-icons",
@@ -19086,6 +21471,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "attach_money",
     "tags": "currency, dollar sign, usd",
     "class": "material-icons",
@@ -19094,6 +21480,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "attachment",
     "tags": "paperclip",
     "class": "material-icons",
@@ -19102,6 +21489,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "audiotrack",
     "tags": "music note",
     "class": "material-icons",
@@ -19110,6 +21498,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "autorenew",
     "tags": "refresh, reload",
     "class": "material-icons",
@@ -19118,6 +21507,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "av_timer",
     "tags": "gauge",
     "class": "material-icons",
@@ -19126,6 +21516,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "backspace",
     "tags": "delete",
     "class": "material-icons",
@@ -19134,6 +21525,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "backup",
     "tags": "cloud, upload",
     "class": "material-icons",
@@ -19142,6 +21534,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "battery_alert",
     "tags": "power",
     "class": "material-icons",
@@ -19150,6 +21543,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "battery_charging_full",
     "tags": "power",
     "class": "material-icons",
@@ -19158,6 +21552,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "battery_full",
     "tags": "power",
     "class": "material-icons",
@@ -19166,6 +21561,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "battery_std",
     "tags": "power",
     "class": "material-icons",
@@ -19174,6 +21570,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "battery_unknown",
     "tags": "power",
     "class": "material-icons",
@@ -19182,6 +21579,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "beenhere",
     "tags": "checkmark",
     "class": "material-icons",
@@ -19190,6 +21588,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "block",
     "tags": "prohibited",
     "class": "material-icons",
@@ -19198,6 +21597,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "bluetooth",
     "tags": "",
     "class": "material-icons",
@@ -19206,6 +21606,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "bluetooth_audio",
     "tags": "",
     "class": "material-icons",
@@ -19214,6 +21615,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "bluetooth_connected",
     "tags": "",
     "class": "material-icons",
@@ -19222,6 +21624,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "bluetooth_disabled",
     "tags": "",
     "class": "material-icons",
@@ -19230,6 +21633,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "bluetooth_searching",
     "tags": "",
     "class": "material-icons",
@@ -19238,6 +21642,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "blur_circular",
     "tags": "",
     "class": "material-icons",
@@ -19246,6 +21651,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "blur_linear",
     "tags": "",
     "class": "material-icons",
@@ -19254,6 +21660,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "blur_off",
     "tags": "",
     "class": "material-icons",
@@ -19262,6 +21669,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "blur_on",
     "tags": "",
     "class": "material-icons",
@@ -19270,6 +21678,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "book",
     "tags": "",
     "class": "material-icons",
@@ -19278,6 +21687,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "bookmark",
     "tags": "",
     "class": "material-icons",
@@ -19286,6 +21696,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "bookmark_border",
     "tags": "",
     "class": "material-icons",
@@ -19294,6 +21705,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "border_all",
     "tags": "",
     "class": "material-icons",
@@ -19302,6 +21714,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "border_bottom",
     "tags": "",
     "class": "material-icons",
@@ -19310,6 +21723,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "border_clear",
     "tags": "",
     "class": "material-icons",
@@ -19318,6 +21732,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "border_color",
     "tags": "",
     "class": "material-icons",
@@ -19326,6 +21741,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "border_horizontal",
     "tags": "",
     "class": "material-icons",
@@ -19334,6 +21750,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "border_inner",
     "tags": "",
     "class": "material-icons",
@@ -19342,6 +21759,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "border_left",
     "tags": "",
     "class": "material-icons",
@@ -19350,6 +21768,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "border_outer",
     "tags": "",
     "class": "material-icons",
@@ -19358,6 +21777,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "border_right",
     "tags": "",
     "class": "material-icons",
@@ -19366,6 +21786,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "border_style",
     "tags": "",
     "class": "material-icons",
@@ -19374,6 +21795,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "border_top",
     "tags": "",
     "class": "material-icons",
@@ -19382,6 +21804,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "border_vertical",
     "tags": "",
     "class": "material-icons",
@@ -19390,6 +21813,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "brightness_1",
     "tags": "circle, full moon",
     "class": "material-icons",
@@ -19398,6 +21822,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "brightness_2",
     "tags": "crescent moon",
     "class": "material-icons",
@@ -19406,6 +21831,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "brightness_3",
     "tags": "crescent moon",
     "class": "material-icons",
@@ -19414,6 +21840,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "brightness_4",
     "tags": "eclipse, moon, sun",
     "class": "material-icons",
@@ -19422,6 +21849,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "brightness_5",
     "tags": "sun",
     "class": "material-icons",
@@ -19430,6 +21858,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "brightness_6",
     "tags": "sun",
     "class": "material-icons",
@@ -19438,6 +21867,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "brightness_7",
     "tags": "sun",
     "class": "material-icons",
@@ -19446,6 +21876,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "brightness_auto",
     "tags": "",
     "class": "material-icons",
@@ -19454,6 +21885,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "brightness_high",
     "tags": "sun",
     "class": "material-icons",
@@ -19462,6 +21894,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "brightness_low",
     "tags": "sun",
     "class": "material-icons",
@@ -19470,6 +21903,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "brightness_medium",
     "tags": "sun",
     "class": "material-icons",
@@ -19478,6 +21912,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "broken_image",
     "tags": "",
     "class": "material-icons",
@@ -19486,6 +21921,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "brush",
     "tags": "paintbrush",
     "class": "material-icons",
@@ -19494,6 +21930,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "bug_report",
     "tags": "",
     "class": "material-icons",
@@ -19502,6 +21939,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "build",
     "tags": "tool, wrench",
     "class": "material-icons",
@@ -19510,6 +21948,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "business",
     "tags": "buildings",
     "class": "material-icons",
@@ -19518,6 +21957,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "cached",
     "tags": "refresh, reload",
     "class": "material-icons",
@@ -19526,6 +21966,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "call",
     "tags": "phone, telephone",
     "class": "material-icons",
@@ -19534,6 +21975,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "call_end",
     "tags": "phone, telephone",
     "class": "material-icons",
@@ -19542,6 +21984,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "call_made",
     "tags": "arrow",
     "class": "material-icons",
@@ -19550,6 +21993,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "call_merge",
     "tags": "arrows, merge",
     "class": "material-icons",
@@ -19558,6 +22002,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "call_missed",
     "tags": "arrow",
     "class": "material-icons",
@@ -19566,6 +22011,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "call_received",
     "tags": "arrow",
     "class": "material-icons",
@@ -19574,6 +22020,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "call_split",
     "tags": "arrows, fork",
     "class": "material-icons",
@@ -19582,6 +22029,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "cake",
     "tags": "birthday",
     "class": "material-icons",
@@ -19590,6 +22038,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "camera",
     "tags": "shutter",
     "class": "material-icons",
@@ -19598,6 +22047,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "camera_alt",
     "tags": "",
     "class": "material-icons",
@@ -19606,6 +22056,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "camera_front",
     "tags": "",
     "class": "material-icons",
@@ -19614,6 +22065,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "camera_enhance",
     "tags": "",
     "class": "material-icons",
@@ -19622,6 +22074,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "camera_rear",
     "tags": "",
     "class": "material-icons",
@@ -19630,6 +22083,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "camera_roll",
     "tags": "film",
     "class": "material-icons",
@@ -19638,6 +22092,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "cancel",
     "tags": "close, remove, x",
     "class": "material-icons",
@@ -19646,6 +22101,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "card_giftcard",
     "tags": "present",
     "class": "material-icons",
@@ -19654,6 +22110,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "card_membership",
     "tags": "",
     "class": "material-icons",
@@ -19662,6 +22119,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "card_travel",
     "tags": "briefcase, luggage, suitcase",
     "class": "material-icons",
@@ -19670,6 +22128,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "cast",
     "tags": "broadcast",
     "class": "material-icons",
@@ -19678,6 +22137,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "cast_connected",
     "tags": "broadcast",
     "class": "material-icons",
@@ -19686,6 +22146,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "center_focus_strong",
     "tags": "",
     "class": "material-icons",
@@ -19694,6 +22155,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "center_focus_weak",
     "tags": "",
     "class": "material-icons",
@@ -19702,6 +22164,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "change_history",
     "tags": "triangle",
     "class": "material-icons",
@@ -19710,6 +22173,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "chat",
     "tags": "speech bubble",
     "class": "material-icons",
@@ -19718,6 +22182,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "chat_bubble",
     "tags": "speech bubble",
     "class": "material-icons",
@@ -19726,6 +22191,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "chat_bubble_outline",
     "tags": "speech bubble",
     "class": "material-icons",
@@ -19734,6 +22200,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "check",
     "tags": "checkmark",
     "class": "material-icons",
@@ -19742,6 +22209,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "check_box",
     "tags": "",
     "class": "material-icons",
@@ -19750,6 +22218,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "check_box_outline",
     "tags": "",
     "class": "material-icons",
@@ -19758,6 +22227,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "check_circle",
     "tags": "",
     "class": "material-icons",
@@ -19766,6 +22236,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "chevron_left",
     "tags": "angle, directional",
     "class": "material-icons",
@@ -19774,6 +22245,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "chevron_right",
     "tags": "angle, directional",
     "class": "material-icons",
@@ -19782,6 +22254,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "chrome_reader_mode",
     "tags": "",
     "class": "material-icons",
@@ -19790,6 +22263,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "class",
     "tags": "bookmark",
     "class": "material-icons",
@@ -19798,6 +22272,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "clear",
     "tags": "close, x",
     "class": "material-icons",
@@ -19806,6 +22281,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "clear_all",
     "tags": "",
     "class": "material-icons",
@@ -19814,6 +22290,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "close",
     "tags": "cancel, remove, x",
     "class": "material-icons",
@@ -19822,6 +22299,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "closed_caption",
     "tags": "",
     "class": "material-icons",
@@ -19830,6 +22308,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "cloud",
     "tags": "",
     "class": "material-icons",
@@ -19838,6 +22317,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "cloud_circle",
     "tags": "",
     "class": "material-icons",
@@ -19846,6 +22326,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "cloud_done",
     "tags": "",
     "class": "material-icons",
@@ -19854,6 +22335,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "cloud_download",
     "tags": "",
     "class": "material-icons",
@@ -19862,6 +22344,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "cloud_off",
     "tags": "",
     "class": "material-icons",
@@ -19870,6 +22353,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "cloud_queue",
     "tags": "",
     "class": "material-icons",
@@ -19878,6 +22362,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "cloud_upload",
     "tags": "",
     "class": "material-icons",
@@ -19886,6 +22371,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "code",
     "tags": "",
     "class": "material-icons",
@@ -19894,6 +22380,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "collections",
     "tags": "",
     "class": "material-icons",
@@ -19902,6 +22389,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "collections_bookmark",
     "tags": "",
     "class": "material-icons",
@@ -19910,6 +22398,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "color_lens",
     "tags": "art, paint, palette",
     "class": "material-icons",
@@ -19918,6 +22407,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "colorize",
     "tags": "eyedropper",
     "class": "material-icons",
@@ -19926,6 +22416,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "comment",
     "tags": "chat, speech bubble",
     "class": "material-icons",
@@ -19934,6 +22425,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "compare",
     "tags": "",
     "class": "material-icons",
@@ -19942,6 +22434,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "computer",
     "tags": "laptop",
     "class": "material-icons",
@@ -19950,6 +22443,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "confirmation_number",
     "tags": "ticket",
     "class": "material-icons",
@@ -19958,6 +22452,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "contact_phone",
     "tags": "",
     "class": "material-icons",
@@ -19966,6 +22461,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "contacts",
     "tags": "",
     "class": "material-icons",
@@ -19974,6 +22470,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "content_copy",
     "tags": "clone, copy",
     "class": "material-icons",
@@ -19982,6 +22479,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "content_cut",
     "tags": "scissors",
     "class": "material-icons",
@@ -19990,6 +22488,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "content_paste",
     "tags": "clipboard",
     "class": "material-icons",
@@ -19998,6 +22497,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "control_point",
     "tags": "plus",
     "class": "material-icons",
@@ -20006,6 +22506,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "control_point_duplicate",
     "tags": "plus",
     "class": "material-icons",
@@ -20014,6 +22515,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "create",
     "tags": "pencil",
     "class": "material-icons",
@@ -20022,6 +22524,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "credit_card",
     "tags": "payment",
     "class": "material-icons",
@@ -20030,6 +22533,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "crop",
     "tags": "",
     "class": "material-icons",
@@ -20038,6 +22542,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "crop_16_9",
     "tags": "aspect ratio",
     "class": "material-icons",
@@ -20046,6 +22551,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "crop_3_2",
     "tags": "aspect ratio",
     "class": "material-icons",
@@ -20054,6 +22560,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "crop_5_4",
     "tags": "aspect ratio",
     "class": "material-icons",
@@ -20062,6 +22569,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "crop_7_5",
     "tags": "aspect ratio",
     "class": "material-icons",
@@ -20070,6 +22578,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "crop_din",
     "tags": "",
     "class": "material-icons",
@@ -20078,6 +22587,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "crop_free",
     "tags": "",
     "class": "material-icons",
@@ -20086,6 +22596,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "crop_landscape",
     "tags": "",
     "class": "material-icons",
@@ -20094,6 +22605,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "crop_original",
     "tags": "",
     "class": "material-icons",
@@ -20102,6 +22614,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "crop_portrait",
     "tags": "",
     "class": "material-icons",
@@ -20110,6 +22623,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "crop_square",
     "tags": "",
     "class": "material-icons",
@@ -20118,6 +22632,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "dashboard",
     "tags": "blocks, grid",
     "class": "material-icons",
@@ -20126,6 +22641,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "data_usage",
     "tags": "pie chart, graph",
     "class": "material-icons",
@@ -20134,6 +22650,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "dehaze",
     "tags": "bars, hamburger menu, more",
     "class": "material-icons",
@@ -20142,6 +22659,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "delete",
     "tags": "trash can",
     "class": "material-icons",
@@ -20150,6 +22668,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "description",
     "tags": "document, file",
     "class": "material-icons",
@@ -20158,6 +22677,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "desktop_mac",
     "tags": "computer, display, monitor",
     "class": "material-icons",
@@ -20166,6 +22686,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "desktop_windows",
     "tags": "computer, display, monitor",
     "class": "material-icons",
@@ -20174,6 +22695,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "details",
     "tags": "triangle",
     "class": "material-icons",
@@ -20182,6 +22704,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "developer_board",
     "tags": "notebook, scrap book",
     "class": "material-icons",
@@ -20190,6 +22713,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "developer_mode",
     "tags": "",
     "class": "material-icons",
@@ -20198,6 +22722,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "device_hub",
     "tags": "",
     "class": "material-icons",
@@ -20206,6 +22731,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "devices",
     "tags": "",
     "class": "material-icons",
@@ -20214,6 +22740,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "dialer_sip",
     "tags": "",
     "class": "material-icons",
@@ -20222,6 +22749,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "dialpad",
     "tags": "",
     "class": "material-icons",
@@ -20230,6 +22758,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "directions",
     "tags": "road sign",
     "class": "material-icons",
@@ -20238,6 +22767,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "directions_bike",
     "tags": "bicycle",
     "class": "material-icons",
@@ -20246,6 +22776,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "directions_boat",
     "tags": "ship",
     "class": "material-icons",
@@ -20254,6 +22785,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "directions_bus",
     "tags": "",
     "class": "material-icons",
@@ -20262,6 +22794,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "directions_car",
     "tags": "automobile, car",
     "class": "material-icons",
@@ -20270,6 +22803,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "directions_railway",
     "tags": "train",
     "class": "material-icons",
@@ -20278,6 +22812,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "directions_run",
     "tags": "person",
     "class": "material-icons",
@@ -20286,6 +22821,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "directions_subway",
     "tags": "",
     "class": "material-icons",
@@ -20294,6 +22830,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "directions_transit",
     "tags": "",
     "class": "material-icons",
@@ -20302,6 +22839,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "directions_walk",
     "tags": "person",
     "class": "material-icons",
@@ -20310,6 +22848,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "disc_full",
     "tags": "record, vinyl",
     "class": "material-icons",
@@ -20318,6 +22857,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "dns",
     "tags": "server",
     "class": "material-icons",
@@ -20326,6 +22866,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "do_not_disturb",
     "tags": "prohibited",
     "class": "material-icons",
@@ -20334,6 +22875,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "do_not_disturb_alt",
     "tags": "prohibited",
     "class": "material-icons",
@@ -20342,6 +22884,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "dock",
     "tags": "phone",
     "class": "material-icons",
@@ -20350,6 +22893,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "domain",
     "tags": "building",
     "class": "material-icons",
@@ -20358,6 +22902,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "done",
     "tags": "check mark",
     "class": "material-icons",
@@ -20366,6 +22911,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "done_all",
     "tags": "check mark",
     "class": "material-icons",
@@ -20374,6 +22920,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "drafts",
     "tags": "envelope, mail",
     "class": "material-icons",
@@ -20382,6 +22929,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "drive_eta",
     "tags": "automobile, car",
     "class": "material-icons",
@@ -20390,6 +22938,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "dvr",
     "tags": "",
     "class": "material-icons",
@@ -20398,6 +22947,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "edit",
     "tags": "pencil",
     "class": "material-icons",
@@ -20406,6 +22956,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "eject",
     "tags": "",
     "class": "material-icons",
@@ -20414,6 +22965,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "email",
     "tags": "envelope, letter",
     "class": "material-icons",
@@ -20422,6 +22974,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "equalizer",
     "tags": "audio, levels, settings",
     "class": "material-icons",
@@ -20430,6 +22983,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "error",
     "tags": "alert, warning",
     "class": "material-icons",
@@ -20438,6 +22992,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "error_outline",
     "tags": "alert, warning",
     "class": "material-icons",
@@ -20446,6 +23001,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "event",
     "tags": "calendar",
     "class": "material-icons",
@@ -20454,6 +23010,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "event_available",
     "tags": "calendar",
     "class": "material-icons",
@@ -20462,6 +23019,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "event_busy",
     "tags": "calendar",
     "class": "material-icons",
@@ -20470,6 +23028,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "event_note",
     "tags": "calendar",
     "class": "material-icons",
@@ -20478,6 +23037,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "event_seat",
     "tags": "chair",
     "class": "material-icons",
@@ -20486,6 +23046,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "exit_to_app",
     "tags": "",
     "class": "material-icons",
@@ -20494,6 +23055,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "expand_less",
     "tags": "angle, chevron, directional, up",
     "class": "material-icons",
@@ -20502,6 +23064,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "expand_more",
     "tags": "angle, chevron, directional, down",
     "class": "material-icons",
@@ -20510,6 +23073,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "explicit",
     "tags": "",
     "class": "material-icons",
@@ -20518,6 +23082,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "explore",
     "tags": "compass, directions",
     "class": "material-icons",
@@ -20526,6 +23091,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "exposure",
     "tags": "brightness, contrast",
     "class": "material-icons",
@@ -20534,6 +23100,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "exposure_neg_1",
     "tags": "",
     "class": "material-icons",
@@ -20542,6 +23109,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "exposure_neg_2",
     "tags": "",
     "class": "material-icons",
@@ -20550,6 +23118,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "exposure_plus_1",
     "tags": "",
     "class": "material-icons",
@@ -20558,6 +23127,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "exposure_plus_2",
     "tags": "",
     "class": "material-icons",
@@ -20566,6 +23136,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "exposure_zero",
     "tags": "",
     "class": "material-icons",
@@ -20574,6 +23145,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "extension",
     "tags": "jigsaw, puzzle",
     "class": "material-icons",
@@ -20582,6 +23154,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "face",
     "tags": "",
     "class": "material-icons",
@@ -20590,6 +23163,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "fast_forward",
     "tags": "",
     "class": "material-icons",
@@ -20598,6 +23172,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "fast_rewind",
     "tags": "",
     "class": "material-icons",
@@ -20606,6 +23181,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "favorite",
     "tags": "heart, like",
     "class": "material-icons",
@@ -20614,6 +23190,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "favorite_border",
     "tags": "heart, like",
     "class": "material-icons",
@@ -20622,6 +23199,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "feedback",
     "tags": "alert, speech bubble",
     "class": "material-icons",
@@ -20630,6 +23208,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "file_download",
     "tags": "",
     "class": "material-icons",
@@ -20638,6 +23217,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "file_upload",
     "tags": "",
     "class": "material-icons",
@@ -20646,6 +23226,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "filter",
     "tags": "",
     "class": "material-icons",
@@ -20654,6 +23235,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "filter_1",
     "tags": "",
     "class": "material-icons",
@@ -20662,6 +23244,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "filter_2",
     "tags": "",
     "class": "material-icons",
@@ -20670,6 +23253,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "filter_3",
     "tags": "",
     "class": "material-icons",
@@ -20678,6 +23262,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "filter_4",
     "tags": "",
     "class": "material-icons",
@@ -20686,6 +23271,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "filter_5",
     "tags": "",
     "class": "material-icons",
@@ -20694,6 +23280,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "filter_6",
     "tags": "",
     "class": "material-icons",
@@ -20702,6 +23289,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "filter_7",
     "tags": "",
     "class": "material-icons",
@@ -20710,6 +23298,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "filter_8",
     "tags": "",
     "class": "material-icons",
@@ -20718,6 +23307,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "filter_9",
     "tags": "",
     "class": "material-icons",
@@ -20726,6 +23316,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "filter_9_plus",
     "tags": "",
     "class": "material-icons",
@@ -20734,6 +23325,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "filter_b_and_w",
     "tags": "",
     "class": "material-icons",
@@ -20742,6 +23334,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "filter_center_focus",
     "tags": "",
     "class": "material-icons",
@@ -20750,6 +23343,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "filter_drama",
     "tags": "cloud",
     "class": "material-icons",
@@ -20758,6 +23352,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "filter_frames",
     "tags": "",
     "class": "material-icons",
@@ -20766,6 +23361,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "filter_hdr",
     "tags": "mountains",
     "class": "material-icons",
@@ -20774,6 +23370,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "filter_list",
     "tags": "",
     "class": "material-icons",
@@ -20782,6 +23379,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "filter_none",
     "tags": "",
     "class": "material-icons",
@@ -20790,6 +23388,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "filter_tilt_shift",
     "tags": "",
     "class": "material-icons",
@@ -20798,6 +23397,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "filter_vintage",
     "tags": "flower",
     "class": "material-icons",
@@ -20806,6 +23406,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "find_in_page",
     "tags": "search, magnifying glass",
     "class": "material-icons",
@@ -20814,6 +23415,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "find_replace",
     "tags": "search, magnifying glass",
     "class": "material-icons",
@@ -20822,6 +23424,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "flag",
     "tags": "",
     "class": "material-icons",
@@ -20830,6 +23433,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "flare",
     "tags": "",
     "class": "material-icons",
@@ -20838,6 +23442,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "flash_auto",
     "tags": "",
     "class": "material-icons",
@@ -20846,6 +23451,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "flash_off",
     "tags": "",
     "class": "material-icons",
@@ -20854,6 +23460,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "flash_on",
     "tags": "",
     "class": "material-icons",
@@ -20862,6 +23469,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "flight",
     "tags": "airplane",
     "class": "material-icons",
@@ -20870,6 +23478,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "flight_land",
     "tags": "airplane, plane, travel",
     "class": "material-icons",
@@ -20878,6 +23487,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "flight_takeoff",
     "tags": "airplane, plane, travel",
     "class": "material-icons",
@@ -20886,6 +23496,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "flip",
     "tags": "",
     "class": "material-icons",
@@ -20894,6 +23505,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "flip_to_back",
     "tags": "",
     "class": "material-icons",
@@ -20902,6 +23514,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "flip_to_front",
     "tags": "",
     "class": "material-icons",
@@ -20910,6 +23523,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "folder",
     "tags": "",
     "class": "material-icons",
@@ -20918,6 +23532,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "folder_open",
     "tags": "",
     "class": "material-icons",
@@ -20926,6 +23541,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "folder_shared",
     "tags": "",
     "class": "material-icons",
@@ -20934,6 +23550,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "folder_special",
     "tags": "star",
     "class": "material-icons",
@@ -20942,6 +23559,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "font_download",
     "tags": "",
     "class": "material-icons",
@@ -20950,6 +23568,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "format_align_center",
     "tags": "",
     "class": "material-icons",
@@ -20958,6 +23577,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "format_align_justify",
     "tags": "",
     "class": "material-icons",
@@ -20966,6 +23586,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "format_align_left",
     "tags": "",
     "class": "material-icons",
@@ -20974,6 +23595,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "format_align_right",
     "tags": "",
     "class": "material-icons",
@@ -20982,6 +23604,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "format_bold",
     "tags": "",
     "class": "material-icons",
@@ -20990,6 +23613,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "format_clear",
     "tags": "",
     "class": "material-icons",
@@ -20998,6 +23622,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "format_color_fill",
     "tags": "paint can",
     "class": "material-icons",
@@ -21006,6 +23631,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "format_color_reset",
     "tags": "droplet",
     "class": "material-icons",
@@ -21014,6 +23640,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "format_color_text",
     "tags": "",
     "class": "material-icons",
@@ -21022,6 +23649,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "format_indent_decrease",
     "tags": "",
     "class": "material-icons",
@@ -21030,6 +23658,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "format_indent_increase",
     "tags": "",
     "class": "material-icons",
@@ -21038,6 +23667,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "format_italic",
     "tags": "",
     "class": "material-icons",
@@ -21046,6 +23676,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "format_line_spacing",
     "tags": "",
     "class": "material-icons",
@@ -21054,6 +23685,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "format_list_bulleted",
     "tags": "",
     "class": "material-icons",
@@ -21062,6 +23694,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "format_list_numbered",
     "tags": "",
     "class": "material-icons",
@@ -21070,6 +23703,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "format_paint",
     "tags": "paint brush, roller",
     "class": "material-icons",
@@ -21078,6 +23712,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "format_quote",
     "tags": "quotation marks",
     "class": "material-icons",
@@ -21086,6 +23721,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "format_size",
     "tags": "",
     "class": "material-icons",
@@ -21094,6 +23730,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "format_strikethrough",
     "tags": "",
     "class": "material-icons",
@@ -21102,6 +23739,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "format_textdirection_l_to_r",
     "tags": "",
     "class": "material-icons",
@@ -21110,6 +23748,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "format_textdirection_r_to_l",
     "tags": "",
     "class": "material-icons",
@@ -21118,6 +23757,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "format_underlined",
     "tags": "",
     "class": "material-icons",
@@ -21126,6 +23766,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "forum",
     "tags": "chat, comments, speech bubbles",
     "class": "material-icons",
@@ -21134,6 +23775,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "forward",
     "tags": "arrow",
     "class": "material-icons",
@@ -21142,6 +23784,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "forward_10",
     "tags": "",
     "class": "material-icons",
@@ -21150,6 +23793,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "forward_30",
     "tags": "",
     "class": "material-icons",
@@ -21158,6 +23802,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "forward_5",
     "tags": "",
     "class": "material-icons",
@@ -21166,6 +23811,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "fullscreen",
     "tags": "",
     "class": "material-icons",
@@ -21174,6 +23820,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "fullscreen_exit",
     "tags": "",
     "class": "material-icons",
@@ -21182,6 +23829,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "functions",
     "tags": "math, sigma",
     "class": "material-icons",
@@ -21190,6 +23838,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "gamepad",
     "tags": "controller",
     "class": "material-icons",
@@ -21198,6 +23847,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "games",
     "tags": "controller, pad",
     "class": "material-icons",
@@ -21206,6 +23856,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "gesture",
     "tags": "scribble",
     "class": "material-icons",
@@ -21214,6 +23865,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "get_app",
     "tags": "download, arrow",
     "class": "material-icons",
@@ -21222,6 +23874,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "gif",
     "tags": "",
     "class": "material-icons",
@@ -21230,6 +23883,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "gps_fixed",
     "tags": "reticle, target",
     "class": "material-icons",
@@ -21238,6 +23892,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "gps_not_fixed",
     "tags": "reticle, target",
     "class": "material-icons",
@@ -21246,6 +23901,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "gps_off",
     "tags": "",
     "class": "material-icons",
@@ -21254,6 +23910,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "grade",
     "tags": "star, rating",
     "class": "material-icons",
@@ -21262,6 +23919,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "gradient",
     "tags": "",
     "class": "material-icons",
@@ -21270,6 +23928,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "grain",
     "tags": "dots",
     "class": "material-icons",
@@ -21278,6 +23937,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "graphic_eq",
     "tags": "",
     "class": "material-icons",
@@ -21286,6 +23946,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "grid_off",
     "tags": "",
     "class": "material-icons",
@@ -21294,6 +23955,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "grid_on",
     "tags": "",
     "class": "material-icons",
@@ -21302,6 +23964,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "group",
     "tags": "people, users",
     "class": "material-icons",
@@ -21310,6 +23973,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "group_add",
     "tags": "",
     "class": "material-icons",
@@ -21318,6 +23982,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "group_work",
     "tags": "circles",
     "class": "material-icons",
@@ -21326,6 +23991,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "hd",
     "tags": "",
     "class": "material-icons",
@@ -21334,6 +24000,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "hdr_off",
     "tags": "",
     "class": "material-icons",
@@ -21342,6 +24009,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "hdr_on",
     "tags": "",
     "class": "material-icons",
@@ -21350,6 +24018,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "hdr_strong",
     "tags": "",
     "class": "material-icons",
@@ -21358,6 +24027,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "hdr_weak",
     "tags": "",
     "class": "material-icons",
@@ -21366,6 +24036,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "healing",
     "tags": "bandage, bandaid, first aid",
     "class": "material-icons",
@@ -21374,6 +24045,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "headset",
     "tags": "headphones",
     "class": "material-icons",
@@ -21382,6 +24054,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "headset_mic",
     "tags": "",
     "class": "material-icons",
@@ -21390,6 +24063,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "hearing",
     "tags": "ear",
     "class": "material-icons",
@@ -21398,6 +24072,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "help",
     "tags": "question mark",
     "class": "material-icons",
@@ -21406,6 +24081,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "help_outline",
     "tags": "question mark",
     "class": "material-icons",
@@ -21414,6 +24090,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "high_quality",
     "tags": "",
     "class": "material-icons",
@@ -21422,6 +24099,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "highlight_off",
     "tags": "x, cancel",
     "class": "material-icons",
@@ -21430,6 +24108,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "history",
     "tags": "",
     "class": "material-icons",
@@ -21438,6 +24117,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "home",
     "tags": "",
     "class": "material-icons",
@@ -21446,6 +24126,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "hotel",
     "tags": "bed",
     "class": "material-icons",
@@ -21454,6 +24135,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "hourglass_empty",
     "tags": "timer",
     "class": "material-icons",
@@ -21462,6 +24144,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "hourglass_full",
     "tags": "timer",
     "class": "material-icons",
@@ -21470,6 +24153,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "http",
     "tags": "",
     "class": "material-icons",
@@ -21478,6 +24162,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "https",
     "tags": "lock, security",
     "class": "material-icons",
@@ -21486,6 +24171,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "image",
     "tags": "",
     "class": "material-icons",
@@ -21494,6 +24180,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "image_aspect_ratio",
     "tags": "",
     "class": "material-icons",
@@ -21502,6 +24189,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "import_export",
     "tags": "arrows",
     "class": "material-icons",
@@ -21510,6 +24198,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "inbox",
     "tags": "email",
     "class": "material-icons",
@@ -21518,6 +24207,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "indeterminate_check_box",
     "tags": "",
     "class": "material-icons",
@@ -21526,6 +24216,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "info",
     "tags": "",
     "class": "material-icons",
@@ -21534,6 +24225,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "info_outline",
     "tags": "",
     "class": "material-icons",
@@ -21542,6 +24234,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "input",
     "tags": "",
     "class": "material-icons",
@@ -21550,6 +24243,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "invert_colors",
     "tags": "adjust, contrast",
     "class": "material-icons",
@@ -21558,6 +24252,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "invert_colors_off",
     "tags": "adjust, contrast",
     "class": "material-icons",
@@ -21566,6 +24261,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "insert_chart",
     "tags": "graph",
     "class": "material-icons",
@@ -21574,6 +24270,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "insert_comment",
     "tags": "chat, speech bubble",
     "class": "material-icons",
@@ -21582,6 +24279,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "insert_drive_file",
     "tags": "document, file, paper",
     "class": "material-icons",
@@ -21590,6 +24288,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "insert_emoticon",
     "tags": "happy, smiley face",
     "class": "material-icons",
@@ -21598,6 +24297,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "insert_invitation",
     "tags": "calendar, date",
     "class": "material-icons",
@@ -21606,6 +24306,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "insert_link",
     "tags": "chain",
     "class": "material-icons",
@@ -21614,6 +24315,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "insert_photo",
     "tags": "image, picture",
     "class": "material-icons",
@@ -21622,6 +24324,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "iso",
     "tags": "",
     "class": "material-icons",
@@ -21630,6 +24333,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "keyboard",
     "tags": "",
     "class": "material-icons",
@@ -21638,6 +24342,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "keyboard_arrow_down",
     "tags": "angle, chevron, directional",
     "class": "material-icons",
@@ -21646,6 +24351,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "keyboard_arrow_left",
     "tags": "angle, chevron, directional",
     "class": "material-icons",
@@ -21654,6 +24360,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "keyboard_arrow_right",
     "tags": "angle, chevron, directional",
     "class": "material-icons",
@@ -21662,6 +24369,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "keyboard_arrow_up",
     "tags": "angle, chevron, directional",
     "class": "material-icons",
@@ -21670,6 +24378,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "keyboard_backspace",
     "tags": "arrow",
     "class": "material-icons",
@@ -21678,6 +24387,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "keyboard_capslock",
     "tags": "",
     "class": "material-icons",
@@ -21686,6 +24396,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "keyboard_hide",
     "tags": "",
     "class": "material-icons",
@@ -21694,6 +24405,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "keyboard_return",
     "tags": "",
     "class": "material-icons",
@@ -21702,6 +24414,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "keyboard_tab",
     "tags": "",
     "class": "material-icons",
@@ -21710,6 +24423,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "keyboard_voice",
     "tags": "",
     "class": "material-icons",
@@ -21718,6 +24432,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "label",
     "tags": "tag",
     "class": "material-icons",
@@ -21726,6 +24441,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "label_outline",
     "tags": "tag",
     "class": "material-icons",
@@ -21734,6 +24450,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "landscape",
     "tags": "mountains",
     "class": "material-icons",
@@ -21742,6 +24459,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "language",
     "tags": "earth, globe, planet",
     "class": "material-icons",
@@ -21750,6 +24468,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "laptop",
     "tags": "computer",
     "class": "material-icons",
@@ -21758,6 +24477,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "laptop_chromebook",
     "tags": "computer",
     "class": "material-icons",
@@ -21766,6 +24486,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "laptop_mac",
     "tags": "computer",
     "class": "material-icons",
@@ -21774,6 +24495,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "laptop_windows",
     "tags": "computer",
     "class": "material-icons",
@@ -21782,6 +24504,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "launch",
     "tags": "open",
     "class": "material-icons",
@@ -21790,6 +24513,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "layers",
     "tags": "",
     "class": "material-icons",
@@ -21798,6 +24522,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "layers_clear",
     "tags": "",
     "class": "material-icons",
@@ -21806,6 +24531,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "leak_add",
     "tags": "",
     "class": "material-icons",
@@ -21814,6 +24540,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "leak_remove",
     "tags": "",
     "class": "material-icons",
@@ -21822,6 +24549,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "lens",
     "tags": "circle",
     "class": "material-icons",
@@ -21830,6 +24558,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "library_add",
     "tags": "",
     "class": "material-icons",
@@ -21838,6 +24567,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "library_books",
     "tags": "",
     "class": "material-icons",
@@ -21846,6 +24576,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "library_music",
     "tags": "",
     "class": "material-icons",
@@ -21854,6 +24585,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "link",
     "tags": "chain",
     "class": "material-icons",
@@ -21862,6 +24594,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "list",
     "tags": "",
     "class": "material-icons",
@@ -21870,6 +24603,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "live_help",
     "tags": "question mark",
     "class": "material-icons",
@@ -21878,6 +24612,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "live_tv",
     "tags": "television",
     "class": "material-icons",
@@ -21886,6 +24621,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "local_activity",
     "tags": "",
     "class": "material-icons",
@@ -21894,6 +24630,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "local_airport",
     "tags": "airplane",
     "class": "material-icons",
@@ -21902,6 +24639,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "local_atm",
     "tags": "dollar sign, money",
     "class": "material-icons",
@@ -21910,6 +24648,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "local_bar",
     "tags": "drink, martini glass",
     "class": "material-icons",
@@ -21918,6 +24657,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "local_cafe",
     "tags": "coffee cup, mug",
     "class": "material-icons",
@@ -21926,6 +24666,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "local_car_wash",
     "tags": "automobile, car",
     "class": "material-icons",
@@ -21934,6 +24675,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "local_convenience_store",
     "tags": "",
     "class": "material-icons",
@@ -21942,6 +24684,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "local_dining",
     "tags": "cutlery, knife, spoon",
     "class": "material-icons",
@@ -21950,6 +24693,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "local_drink",
     "tags": "cup, droplet, glass, juice",
     "class": "material-icons",
@@ -21958,6 +24702,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "local_florist",
     "tags": "flower, plant",
     "class": "material-icons",
@@ -21966,6 +24711,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "local_gas_station",
     "tags": "gas pump",
     "class": "material-icons",
@@ -21974,6 +24720,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "local_grocery_store",
     "tags": "shopping cart",
     "class": "material-icons",
@@ -21982,6 +24729,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "local_hospital",
     "tags": "first aid, medical",
     "class": "material-icons",
@@ -21990,6 +24738,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "local_hotel",
     "tags": "bed",
     "class": "material-icons",
@@ -21998,6 +24747,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "local_laundry_service",
     "tags": "washing machine",
     "class": "material-icons",
@@ -22006,6 +24756,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "local_library",
     "tags": "book",
     "class": "material-icons",
@@ -22014,6 +24765,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "local_mall",
     "tags": "shopping bag",
     "class": "material-icons",
@@ -22022,6 +24774,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "local_movies",
     "tags": "film",
     "class": "material-icons",
@@ -22030,6 +24783,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "local_offer",
     "tags": "sale, tag",
     "class": "material-icons",
@@ -22038,6 +24792,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "local_parking",
     "tags": "p",
     "class": "material-icons",
@@ -22046,6 +24801,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "local_pharmacy",
     "tags": "drug store, medicine",
     "class": "material-icons",
@@ -22054,6 +24810,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "local_phone",
     "tags": "telephone",
     "class": "material-icons",
@@ -22062,6 +24819,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "local_pizza",
     "tags": "food, slice",
     "class": "material-icons",
@@ -22070,6 +24828,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "local_play",
     "tags": "admission, ticket",
     "class": "material-icons",
@@ -22078,6 +24837,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "local_post_office",
     "tags": "envelope, mail",
     "class": "material-icons",
@@ -22086,6 +24846,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "local_print_shop",
     "tags": "printer",
     "class": "material-icons",
@@ -22094,6 +24855,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "local_see",
     "tags": "camera",
     "class": "material-icons",
@@ -22102,6 +24864,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "local_shipping",
     "tags": "truck",
     "class": "material-icons",
@@ -22110,6 +24873,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "local_taxi",
     "tags": "automobile, cab, car",
     "class": "material-icons",
@@ -22118,6 +24882,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "location_city",
     "tags": "city, buildings, skyscrapers",
     "class": "material-icons",
@@ -22126,6 +24891,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "location_disabled",
     "tags": "",
     "class": "material-icons",
@@ -22134,6 +24900,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "location_off",
     "tags": "",
     "class": "material-icons",
@@ -22142,6 +24909,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "location_on",
     "tags": "",
     "class": "material-icons",
@@ -22150,6 +24918,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "location_searching",
     "tags": "",
     "class": "material-icons",
@@ -22158,6 +24927,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "lock",
     "tags": "security",
     "class": "material-icons",
@@ -22166,6 +24936,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "lock_open",
     "tags": "security, unlock",
     "class": "material-icons",
@@ -22174,6 +24945,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "lock_outline",
     "tags": "security",
     "class": "material-icons",
@@ -22182,6 +24954,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "looks",
     "tags": "rainbow",
     "class": "material-icons",
@@ -22190,6 +24963,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "looks_3",
     "tags": "",
     "class": "material-icons",
@@ -22198,6 +24972,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "looks_4",
     "tags": "",
     "class": "material-icons",
@@ -22206,6 +24981,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "looks_5",
     "tags": "",
     "class": "material-icons",
@@ -22214,6 +24990,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "looks_one",
     "tags": "",
     "class": "material-icons",
@@ -22222,6 +24999,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "looks_two",
     "tags": "",
     "class": "material-icons",
@@ -22230,6 +25008,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "loop",
     "tags": "refresh, reload",
     "class": "material-icons",
@@ -22238,6 +25017,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "loupe",
     "tags": "",
     "class": "material-icons",
@@ -22246,6 +25026,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "loyalty",
     "tags": "heart, tag",
     "class": "material-icons",
@@ -22254,6 +25035,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "mail",
     "tags": "envelope",
     "class": "material-icons",
@@ -22262,6 +25044,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "map",
     "tags": "",
     "class": "material-icons",
@@ -22270,6 +25053,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "markunread",
     "tags": "envelope, mail",
     "class": "material-icons",
@@ -22278,6 +25062,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "markunread_mailbox",
     "tags": "mailbox",
     "class": "material-icons",
@@ -22286,6 +25071,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "memory",
     "tags": "chip, circuit board",
     "class": "material-icons",
@@ -22294,6 +25080,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "menu",
     "tags": "bars, more",
     "class": "material-icons",
@@ -22302,6 +25089,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "merge_type",
     "tags": "arrows",
     "class": "material-icons",
@@ -22310,6 +25098,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "message",
     "tags": "chat, speech bubble",
     "class": "material-icons",
@@ -22318,6 +25107,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "mic",
     "tags": "",
     "class": "material-icons",
@@ -22326,6 +25116,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "mic_none",
     "tags": "",
     "class": "material-icons",
@@ -22334,6 +25125,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "mic_off",
     "tags": "mute",
     "class": "material-icons",
@@ -22342,6 +25134,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "mms",
     "tags": "speech bubble",
     "class": "material-icons",
@@ -22350,6 +25143,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "mode_comment",
     "tags": "chat, speech bubble",
     "class": "material-icons",
@@ -22358,6 +25152,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "mode_edit",
     "tags": "pencil",
     "class": "material-icons",
@@ -22366,6 +25161,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "money_off",
     "tags": "currency, dollar sign, usd",
     "class": "material-icons",
@@ -22374,6 +25170,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "monochrome_photos",
     "tags": "",
     "class": "material-icons",
@@ -22382,6 +25179,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "mood",
     "tags": "happy, smiley face",
     "class": "material-icons",
@@ -22390,6 +25188,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "mood_bad",
     "tags": "frowny face, sad",
     "class": "material-icons",
@@ -22398,6 +25197,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "more",
     "tags": "tag",
     "class": "material-icons",
@@ -22406,6 +25206,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "more_horiz",
     "tags": "dots",
     "class": "material-icons",
@@ -22414,6 +25215,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "more_vert",
     "tags": "dots",
     "class": "material-icons",
@@ -22422,6 +25224,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "mouse",
     "tags": "",
     "class": "material-icons",
@@ -22430,6 +25233,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "movie",
     "tags": "film",
     "class": "material-icons",
@@ -22438,6 +25242,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "movie_creation",
     "tags": "film marker",
     "class": "material-icons",
@@ -22446,6 +25251,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "music_note",
     "tags": "",
     "class": "material-icons",
@@ -22454,6 +25260,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "my_location",
     "tags": "reticle, target",
     "class": "material-icons",
@@ -22462,6 +25269,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "navigation",
     "tags": "arrow",
     "class": "material-icons",
@@ -22470,6 +25278,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "nature",
     "tags": "tree",
     "class": "material-icons",
@@ -22478,6 +25287,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "nature_people",
     "tags": "tree",
     "class": "material-icons",
@@ -22486,6 +25296,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "navigate_before",
     "tags": "angle, directional",
     "class": "material-icons",
@@ -22494,6 +25305,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "navigate_next",
     "tags": "angle, directional",
     "class": "material-icons",
@@ -22502,6 +25314,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "network_cell",
     "tags": "",
     "class": "material-icons",
@@ -22510,6 +25323,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "network_locked",
     "tags": "",
     "class": "material-icons",
@@ -22518,6 +25332,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "network_wifi",
     "tags": "",
     "class": "material-icons",
@@ -22526,6 +25341,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "new_releases",
     "tags": "alert",
     "class": "material-icons",
@@ -22534,6 +25350,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "nfc",
     "tags": "chip, circuit board",
     "class": "material-icons",
@@ -22542,6 +25359,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "no_sim",
     "tags": "",
     "class": "material-icons",
@@ -22550,6 +25368,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "not_interested",
     "tags": "ban, prohibited",
     "class": "material-icons",
@@ -22558,6 +25377,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "note_add",
     "tags": "",
     "class": "material-icons",
@@ -22566,6 +25386,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "notifications",
     "tags": "bell",
     "class": "material-icons",
@@ -22574,6 +25395,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "notifications_active",
     "tags": "bell",
     "class": "material-icons",
@@ -22582,6 +25404,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "notifications_none",
     "tags": "bell",
     "class": "material-icons",
@@ -22590,6 +25413,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "notifications_off",
     "tags": "bell",
     "class": "material-icons",
@@ -22598,6 +25422,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "notifications_paused",
     "tags": "bell",
     "class": "material-icons",
@@ -22606,6 +25431,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "offline_pin",
     "tags": "",
     "class": "material-icons",
@@ -22614,6 +25440,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "ondemand_video",
     "tags": "",
     "class": "material-icons",
@@ -22622,6 +25449,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "open_in_browser",
     "tags": "",
     "class": "material-icons",
@@ -22630,6 +25458,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "open_in_new",
     "tags": "",
     "class": "material-icons",
@@ -22638,6 +25467,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "open_with",
     "tags": "expand, resize",
     "class": "material-icons",
@@ -22646,6 +25476,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "pages",
     "tags": "",
     "class": "material-icons",
@@ -22654,6 +25485,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "pageview",
     "tags": "find, magnifying glass, search",
     "class": "material-icons",
@@ -22662,6 +25494,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "palette",
     "tags": "art, paint",
     "class": "material-icons",
@@ -22670,6 +25503,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "panorama",
     "tags": "",
     "class": "material-icons",
@@ -22678,6 +25512,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "panorama_fish_eye",
     "tags": "circle",
     "class": "material-icons",
@@ -22686,6 +25521,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "panorama_horizontal",
     "tags": "",
     "class": "material-icons",
@@ -22694,6 +25530,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "panorama_vertical",
     "tags": "",
     "class": "material-icons",
@@ -22702,6 +25539,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "panorama_wide_angle",
     "tags": "",
     "class": "material-icons",
@@ -22710,6 +25548,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "party_mode",
     "tags": "camera",
     "class": "material-icons",
@@ -22718,6 +25557,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "pause",
     "tags": "",
     "class": "material-icons",
@@ -22726,6 +25566,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "pause_circle_filled",
     "tags": "",
     "class": "material-icons",
@@ -22734,6 +25575,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "pause_circle_outline",
     "tags": "",
     "class": "material-icons",
@@ -22742,6 +25584,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "payment",
     "tags": "credit card",
     "class": "material-icons",
@@ -22750,6 +25593,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "people",
     "tags": "users",
     "class": "material-icons",
@@ -22758,6 +25602,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "people_outline",
     "tags": "users",
     "class": "material-icons",
@@ -22766,6 +25611,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "perm_camera_mic",
     "tags": "camera, microphone",
     "class": "material-icons",
@@ -22774,6 +25620,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "perm_contact_calendar",
     "tags": "contact, calendar",
     "class": "material-icons",
@@ -22782,6 +25629,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "perm_data_setting",
     "tags": "",
     "class": "material-icons",
@@ -22790,6 +25638,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "perm_device_information",
     "tags": "",
     "class": "material-icons",
@@ -22798,6 +25647,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "perm_identity",
     "tags": "user",
     "class": "material-icons",
@@ -22806,6 +25656,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "perm_media",
     "tags": "",
     "class": "material-icons",
@@ -22814,6 +25665,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "perm_phone_msg",
     "tags": "telephone",
     "class": "material-icons",
@@ -22822,6 +25674,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "perm_scan_wifi",
     "tags": "",
     "class": "material-icons",
@@ -22830,6 +25683,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "person",
     "tags": "user",
     "class": "material-icons",
@@ -22838,6 +25692,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "person_add",
     "tags": "user",
     "class": "material-icons",
@@ -22846,6 +25701,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "person_outline",
     "tags": "user",
     "class": "material-icons",
@@ -22854,6 +25710,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "person_pin",
     "tags": "",
     "class": "material-icons",
@@ -22862,6 +25719,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "personal_video",
     "tags": "",
     "class": "material-icons",
@@ -22870,6 +25728,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "phone",
     "tags": "telephone",
     "class": "material-icons",
@@ -22878,6 +25737,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "phone_android",
     "tags": "",
     "class": "material-icons",
@@ -22886,6 +25746,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "phone_bluetooth_speaker",
     "tags": "",
     "class": "material-icons",
@@ -22894,6 +25755,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "phone_forwarded",
     "tags": "",
     "class": "material-icons",
@@ -22902,6 +25764,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "phone_in_talk",
     "tags": "",
     "class": "material-icons",
@@ -22910,6 +25773,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "phone_iphone",
     "tags": "",
     "class": "material-icons",
@@ -22918,6 +25782,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "phone_locked",
     "tags": "",
     "class": "material-icons",
@@ -22926,6 +25791,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "phone_missed",
     "tags": "",
     "class": "material-icons",
@@ -22934,6 +25800,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "phone_paused",
     "tags": "",
     "class": "material-icons",
@@ -22942,6 +25809,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "phonelink",
     "tags": "",
     "class": "material-icons",
@@ -22950,6 +25818,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "phonelink_erase",
     "tags": "",
     "class": "material-icons",
@@ -22958,6 +25827,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "phonelink_lock",
     "tags": "",
     "class": "material-icons",
@@ -22966,6 +25836,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "phonelink_off",
     "tags": "",
     "class": "material-icons",
@@ -22974,6 +25845,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "phonelink_ring",
     "tags": "",
     "class": "material-icons",
@@ -22982,6 +25854,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "phonelink_setup",
     "tags": "",
     "class": "material-icons",
@@ -22990,6 +25863,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "photo",
     "tags": "",
     "class": "material-icons",
@@ -22998,6 +25872,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "photo_album",
     "tags": "",
     "class": "material-icons",
@@ -23006,6 +25881,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "photo_camera",
     "tags": "",
     "class": "material-icons",
@@ -23014,6 +25890,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "photo_library",
     "tags": "",
     "class": "material-icons",
@@ -23022,6 +25899,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "photo_size_select_actual",
     "tags": "",
     "class": "material-icons",
@@ -23030,6 +25908,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "photo_size_select_large",
     "tags": "",
     "class": "material-icons",
@@ -23038,6 +25917,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "photo_size_select_small",
     "tags": "",
     "class": "material-icons",
@@ -23046,6 +25926,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "picture_as_pdf",
     "tags": "",
     "class": "material-icons",
@@ -23054,6 +25935,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "picture_in_picture",
     "tags": "",
     "class": "material-icons",
@@ -23062,6 +25944,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "pin_drop",
     "tags": "map marker",
     "class": "material-icons",
@@ -23070,6 +25953,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "place",
     "tags": "map marker",
     "class": "material-icons",
@@ -23078,6 +25962,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "play_arrow",
     "tags": "triangle",
     "class": "material-icons",
@@ -23086,6 +25971,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "play_circle_filled",
     "tags": "triangle",
     "class": "material-icons",
@@ -23094,6 +25980,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "play_circle_outline",
     "tags": "triangle",
     "class": "material-icons",
@@ -23102,6 +25989,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "play_for_work",
     "tags": "",
     "class": "material-icons",
@@ -23110,6 +25998,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "playlist_add",
     "tags": "",
     "class": "material-icons",
@@ -23118,6 +26007,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "plus_one",
     "tags": "",
     "class": "material-icons",
@@ -23126,6 +26016,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "poll",
     "tags": "chart, graph",
     "class": "material-icons",
@@ -23134,6 +26025,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "polymer",
     "tags": "brand, logo",
     "class": "material-icons",
@@ -23142,6 +26034,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "portable_wifi_off",
     "tags": "",
     "class": "material-icons",
@@ -23150,6 +26043,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "portrait",
     "tags": "",
     "class": "material-icons",
@@ -23158,6 +26052,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "power",
     "tags": "plug",
     "class": "material-icons",
@@ -23166,6 +26061,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "power_input",
     "tags": "",
     "class": "material-icons",
@@ -23174,6 +26070,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "power_settings_new",
     "tags": "on, switch",
     "class": "material-icons",
@@ -23182,6 +26079,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "present_to_all",
     "tags": "",
     "class": "material-icons",
@@ -23190,6 +26088,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "print",
     "tags": "",
     "class": "material-icons",
@@ -23198,6 +26097,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "public",
     "tags": "earth, globe, planet",
     "class": "material-icons",
@@ -23206,6 +26106,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "publish",
     "tags": "upload",
     "class": "material-icons",
@@ -23214,6 +26115,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "query_builder",
     "tags": "clock",
     "class": "material-icons",
@@ -23222,6 +26124,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "question_answer",
     "tags": "chat, speech bubbles",
     "class": "material-icons",
@@ -23230,6 +26133,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "queue",
     "tags": "",
     "class": "material-icons",
@@ -23238,6 +26142,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "queue_music",
     "tags": "",
     "class": "material-icons",
@@ -23246,6 +26151,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "radio",
     "tags": "music",
     "class": "material-icons",
@@ -23254,6 +26160,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "radio_button_checked",
     "tags": "",
     "class": "material-icons",
@@ -23262,6 +26169,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "radio_button_unchecked",
     "tags": "",
     "class": "material-icons",
@@ -23270,6 +26178,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "rate_review",
     "tags": "",
     "class": "material-icons",
@@ -23278,6 +26187,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "receipt",
     "tags": "",
     "class": "material-icons",
@@ -23286,6 +26196,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "recent_actors",
     "tags": "",
     "class": "material-icons",
@@ -23294,6 +26205,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "redeem",
     "tags": "gift card, present",
     "class": "material-icons",
@@ -23302,6 +26214,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "redo",
     "tags": "arrow",
     "class": "material-icons",
@@ -23310,6 +26223,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "refresh",
     "tags": "reload",
     "class": "material-icons",
@@ -23318,6 +26232,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "remove",
     "tags": "minus",
     "class": "material-icons",
@@ -23326,6 +26241,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "remove_circle",
     "tags": "minus",
     "class": "material-icons",
@@ -23334,6 +26250,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "remove_circle_outline",
     "tags": "minus",
     "class": "material-icons",
@@ -23342,6 +26259,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "remove_red_eye",
     "tags": "eyeball",
     "class": "material-icons",
@@ -23350,6 +26268,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "reorder",
     "tags": "bars, menu, more",
     "class": "material-icons",
@@ -23358,6 +26277,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "repeat",
     "tags": "loop",
     "class": "material-icons",
@@ -23366,6 +26286,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "repeat_one",
     "tags": "loop",
     "class": "material-icons",
@@ -23374,6 +26295,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "replay",
     "tags": "",
     "class": "material-icons",
@@ -23382,6 +26304,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "replay_10",
     "tags": "",
     "class": "material-icons",
@@ -23390,6 +26313,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "replay_30",
     "tags": "",
     "class": "material-icons",
@@ -23398,6 +26322,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "replay_5",
     "tags": "",
     "class": "material-icons",
@@ -23406,6 +26331,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "reply",
     "tags": "arrow",
     "class": "material-icons",
@@ -23414,6 +26340,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "reply_all",
     "tags": "arrow",
     "class": "material-icons",
@@ -23422,6 +26349,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "report",
     "tags": "alert, warning",
     "class": "material-icons",
@@ -23430,6 +26358,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "report_problem",
     "tags": "alert, warning",
     "class": "material-icons",
@@ -23438,6 +26367,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "restaurant",
     "tags": "cutlery, dining, knife, spoon",
     "class": "material-icons",
@@ -23446,6 +26376,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "restore",
     "tags": "",
     "class": "material-icons",
@@ -23454,6 +26385,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "ring_volume",
     "tags": "",
     "class": "material-icons",
@@ -23462,6 +26394,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "room",
     "tags": "map marker",
     "class": "material-icons",
@@ -23470,6 +26403,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "rotate_90_degrees_ccw",
     "tags": "",
     "class": "material-icons",
@@ -23478,6 +26412,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "rotate_left",
     "tags": "",
     "class": "material-icons",
@@ -23486,6 +26421,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "rotate_right",
     "tags": "",
     "class": "material-icons",
@@ -23494,6 +26430,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "router",
     "tags": "",
     "class": "material-icons",
@@ -23502,6 +26439,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "satellite",
     "tags": "",
     "class": "material-icons",
@@ -23510,6 +26448,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "scanner",
     "tags": "",
     "class": "material-icons",
@@ -23518,6 +26457,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "save",
     "tags": "floppy disk",
     "class": "material-icons",
@@ -23526,6 +26466,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "schedule",
     "tags": "clock",
     "class": "material-icons",
@@ -23534,6 +26475,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "school",
     "tags": "education, graduation cap, hat",
     "class": "material-icons",
@@ -23542,6 +26484,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "screen_lock_landscape",
     "tags": "",
     "class": "material-icons",
@@ -23550,6 +26493,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "screen_lock_portrait",
     "tags": "",
     "class": "material-icons",
@@ -23558,6 +26502,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "screen_lock_rotation",
     "tags": "",
     "class": "material-icons",
@@ -23566,6 +26511,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "screen_rotation",
     "tags": "",
     "class": "material-icons",
@@ -23574,6 +26520,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "sd_card",
     "tags": "memory",
     "class": "material-icons",
@@ -23582,6 +26529,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "sd_storage",
     "tags": "memory",
     "class": "material-icons",
@@ -23590,6 +26538,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "search",
     "tags": "find, magnifying glass",
     "class": "material-icons",
@@ -23598,6 +26547,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "security",
     "tags": "shield",
     "class": "material-icons",
@@ -23606,6 +26556,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "select_all",
     "tags": "",
     "class": "material-icons",
@@ -23614,6 +26565,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "send",
     "tags": "paper airplane",
     "class": "material-icons",
@@ -23622,6 +26574,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "settings",
     "tags": "cog, gear",
     "class": "material-icons",
@@ -23630,6 +26583,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "settings_applications",
     "tags": "cog, gear",
     "class": "material-icons",
@@ -23638,6 +26592,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "settings_backup_restore",
     "tags": "",
     "class": "material-icons",
@@ -23646,6 +26601,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "settings_bluetooth",
     "tags": "",
     "class": "material-icons",
@@ -23654,6 +26610,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "settings_brightness",
     "tags": "adjust, contrast",
     "class": "material-icons",
@@ -23662,6 +26619,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "settings_cell",
     "tags": "phone",
     "class": "material-icons",
@@ -23670,6 +26628,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "settings_ethernet",
     "tags": "",
     "class": "material-icons",
@@ -23678,6 +26637,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "settings_input_antenna",
     "tags": "",
     "class": "material-icons",
@@ -23686,6 +26646,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "settings_input_component",
     "tags": "cables, wires",
     "class": "material-icons",
@@ -23694,6 +26655,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "settings_input_composite",
     "tags": "cables, wires",
     "class": "material-icons",
@@ -23702,6 +26664,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "settings_input_hdmi",
     "tags": "cables, wires",
     "class": "material-icons",
@@ -23710,6 +26673,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "settings_input_svideo",
     "tags": "cables, wires",
     "class": "material-icons",
@@ -23718,6 +26682,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "settings_overscan",
     "tags": "",
     "class": "material-icons",
@@ -23726,6 +26691,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "settings_phone",
     "tags": "",
     "class": "material-icons",
@@ -23734,6 +26700,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "settings_power",
     "tags": "on, switch",
     "class": "material-icons",
@@ -23742,6 +26709,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "settings_remote",
     "tags": "remote control",
     "class": "material-icons",
@@ -23750,6 +26718,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "settings_system_daydream",
     "tags": "",
     "class": "material-icons",
@@ -23758,6 +26727,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "settings_voice",
     "tags": "microphone",
     "class": "material-icons",
@@ -23766,6 +26736,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "share",
     "tags": "",
     "class": "material-icons",
@@ -23774,6 +26745,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "shop",
     "tags": "bag",
     "class": "material-icons",
@@ -23782,6 +26754,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "shop_two",
     "tags": "bags",
     "class": "material-icons",
@@ -23790,6 +26763,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "shopping_basket",
     "tags": "",
     "class": "material-icons",
@@ -23798,6 +26772,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "shopping_cart",
     "tags": "",
     "class": "material-icons",
@@ -23806,6 +26781,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "shuffle",
     "tags": "random",
     "class": "material-icons",
@@ -23814,6 +26790,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "signal_cellular_4_bar",
     "tags": "",
     "class": "material-icons",
@@ -23822,6 +26799,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "signal_cellular_connected_no_internet_4_bar",
     "tags": "",
     "class": "material-icons",
@@ -23830,6 +26808,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "signal_cellular_no_sim",
     "tags": "",
     "class": "material-icons",
@@ -23838,6 +26817,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "signal_cellular_null",
     "tags": "",
     "class": "material-icons",
@@ -23846,6 +26826,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "signal_cellular_off",
     "tags": "",
     "class": "material-icons",
@@ -23854,6 +26835,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "signal_wifi_4_bar",
     "tags": "",
     "class": "material-icons",
@@ -23862,6 +26844,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "signal_wifi_4_bar_lock",
     "tags": "",
     "class": "material-icons",
@@ -23870,6 +26853,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "signal_wifi_off",
     "tags": "",
     "class": "material-icons",
@@ -23878,6 +26862,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "sim_card",
     "tags": "memory",
     "class": "material-icons",
@@ -23886,6 +26871,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "sim_cart_alert",
     "tags": "memory",
     "class": "material-icons",
@@ -23894,6 +26880,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "skip_next",
     "tags": "",
     "class": "material-icons",
@@ -23902,6 +26889,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "skip_previous",
     "tags": "",
     "class": "material-icons",
@@ -23910,6 +26898,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "slideshow",
     "tags": "play",
     "class": "material-icons",
@@ -23918,6 +26907,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "smartphone",
     "tags": "",
     "class": "material-icons",
@@ -23926,6 +26916,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "sms",
     "tags": "speech bubble",
     "class": "material-icons",
@@ -23934,6 +26925,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "sms_failed",
     "tags": "speech bubble",
     "class": "material-icons",
@@ -23942,6 +26934,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "sort",
     "tags": "",
     "class": "material-icons",
@@ -23950,6 +26943,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "speaker",
     "tags": "",
     "class": "material-icons",
@@ -23958,6 +26952,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "speaker_group",
     "tags": "",
     "class": "material-icons",
@@ -23966,6 +26961,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "speaker_notes",
     "tags": "speech bubble",
     "class": "material-icons",
@@ -23974,6 +26970,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "spellcheck",
     "tags": "",
     "class": "material-icons",
@@ -23982,6 +26979,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "snooze",
     "tags": "alarm clock",
     "class": "material-icons",
@@ -23990,6 +26988,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "sort_by_alpha",
     "tags": "",
     "class": "material-icons",
@@ -23998,6 +26997,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "space_bar",
     "tags": "",
     "class": "material-icons",
@@ -24006,6 +27006,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "speaker_phone",
     "tags": "telephone",
     "class": "material-icons",
@@ -24014,6 +27015,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "star",
     "tags": "rating",
     "class": "material-icons",
@@ -24022,6 +27024,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "star_border",
     "tags": "rating",
     "class": "material-icons",
@@ -24030,6 +27033,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "star_half",
     "tags": "rating",
     "class": "material-icons",
@@ -24038,6 +27042,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "stars",
     "tags": "rating",
     "class": "material-icons",
@@ -24046,6 +27051,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "stay_current_landscape",
     "tags": "tablet, phone",
     "class": "material-icons",
@@ -24054,6 +27060,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "stay_current_portrait",
     "tags": "tablet, phone",
     "class": "material-icons",
@@ -24062,6 +27069,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "stay_primary_landscape",
     "tags": "tablet, phone",
     "class": "material-icons",
@@ -24070,6 +27078,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "stay_primary_portrait",
     "tags": "tablet, phone",
     "class": "material-icons",
@@ -24078,6 +27087,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "strikethrough_s",
     "tags": "",
     "class": "material-icons",
@@ -24086,6 +27096,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "stop",
     "tags": "square",
     "class": "material-icons",
@@ -24094,6 +27105,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "storage",
     "tags": "server",
     "class": "material-icons",
@@ -24102,6 +27114,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "store",
     "tags": "building, shop",
     "class": "material-icons",
@@ -24110,6 +27123,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "store_mall_directory",
     "tags": "building, shop",
     "class": "material-icons",
@@ -24118,6 +27132,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "straighten",
     "tags": "comb",
     "class": "material-icons",
@@ -24126,6 +27141,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "style",
     "tags": "swatches",
     "class": "material-icons",
@@ -24134,6 +27150,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "subject",
     "tags": "",
     "class": "material-icons",
@@ -24142,6 +27159,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "subtitles",
     "tags": "",
     "class": "material-icons",
@@ -24150,6 +27168,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "supervisor_account",
     "tags": "",
     "class": "material-icons",
@@ -24158,6 +27177,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "surround_sound",
     "tags": "",
     "class": "material-icons",
@@ -24166,6 +27186,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "swap_calls",
     "tags": "arrows",
     "class": "material-icons",
@@ -24174,6 +27195,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "swap_horiz",
     "tags": "arrows",
     "class": "material-icons",
@@ -24182,6 +27204,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "swap_vert",
     "tags": "arrows",
     "class": "material-icons",
@@ -24190,6 +27213,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "swap_vertical_circle",
     "tags": "",
     "class": "material-icons",
@@ -24198,6 +27222,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "switch_camera",
     "tags": "",
     "class": "material-icons",
@@ -24206,6 +27231,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "switch_video",
     "tags": "",
     "class": "material-icons",
@@ -24214,6 +27240,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "sync",
     "tags": "refresh, reload",
     "class": "material-icons",
@@ -24222,6 +27249,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "sync_disabled",
     "tags": "",
     "class": "material-icons",
@@ -24230,6 +27258,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "sync_problem",
     "tags": "",
     "class": "material-icons",
@@ -24238,6 +27267,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "system_update",
     "tags": "",
     "class": "material-icons",
@@ -24246,6 +27276,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "system_update_alt",
     "tags": "download",
     "class": "material-icons",
@@ -24254,6 +27285,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "tab",
     "tags": "folder",
     "class": "material-icons",
@@ -24262,6 +27294,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "tab_unselected",
     "tags": "",
     "class": "material-icons",
@@ -24270,6 +27303,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "tablet",
     "tags": "",
     "class": "material-icons",
@@ -24278,6 +27312,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "tablet_android",
     "tags": "",
     "class": "material-icons",
@@ -24286,6 +27321,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "tablet_mac",
     "tags": "ipad",
     "class": "material-icons",
@@ -24294,6 +27330,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "tag_faces",
     "tags": "",
     "class": "material-icons",
@@ -24302,6 +27339,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "tap_and_play",
     "tags": "",
     "class": "material-icons",
@@ -24310,6 +27348,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "terrain",
     "tags": "mountains",
     "class": "material-icons",
@@ -24318,6 +27357,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "text_format",
     "tags": "",
     "class": "material-icons",
@@ -24326,6 +27366,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "textsms",
     "tags": "chat, sms, speech bubble",
     "class": "material-icons",
@@ -24334,6 +27375,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "texture",
     "tags": "",
     "class": "material-icons",
@@ -24342,6 +27384,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "theaters",
     "tags": "film, movie",
     "class": "material-icons",
@@ -24350,6 +27393,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "thumb_down",
     "tags": "dislike, rating",
     "class": "material-icons",
@@ -24358,6 +27402,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "thumb_up",
     "tags": "like, rating",
     "class": "material-icons",
@@ -24366,6 +27411,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "time_to_leave",
     "tags": "automobile, car",
     "class": "material-icons",
@@ -24374,6 +27420,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "timelapse",
     "tags": "",
     "class": "material-icons",
@@ -24382,6 +27429,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "timer",
     "tags": "stopwatch",
     "class": "material-icons",
@@ -24390,6 +27438,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "timer_10",
     "tags": "",
     "class": "material-icons",
@@ -24398,6 +27447,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "timer_3",
     "tags": "",
     "class": "material-icons",
@@ -24406,6 +27456,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "timer_off",
     "tags": "stopwatch",
     "class": "material-icons",
@@ -24414,6 +27465,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "toc",
     "tags": "rows",
     "class": "material-icons",
@@ -24422,6 +27474,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "today",
     "tags": "calendar, date",
     "class": "material-icons",
@@ -24430,6 +27483,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "toll",
     "tags": "circle, coin",
     "class": "material-icons",
@@ -24438,6 +27492,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "tonality",
     "tags": "contrast",
     "class": "material-icons",
@@ -24446,6 +27501,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "toys",
     "tags": "pinwheel",
     "class": "material-icons",
@@ -24454,6 +27510,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "track_changes",
     "tags": "radar",
     "class": "material-icons",
@@ -24462,6 +27519,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "traffic",
     "tags": "light, signal",
     "class": "material-icons",
@@ -24470,6 +27528,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "transform",
     "tags": "",
     "class": "material-icons",
@@ -24478,6 +27537,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "translate",
     "tags": "language",
     "class": "material-icons",
@@ -24486,6 +27546,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "trending_down",
     "tags": "arrow, chart, graph",
     "class": "material-icons",
@@ -24494,6 +27555,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "trending_flat",
     "tags": "arrow, chart, graph",
     "class": "material-icons",
@@ -24502,6 +27564,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "trending_up",
     "tags": "arrow, chart, graph",
     "class": "material-icons",
@@ -24510,6 +27573,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "tune",
     "tags": "equalizer, levels, settings",
     "class": "material-icons",
@@ -24518,6 +27582,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "turned_in",
     "tags": "bookmark",
     "class": "material-icons",
@@ -24526,6 +27591,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "turned_in_not",
     "tags": "bookmark",
     "class": "material-icons",
@@ -24534,6 +27600,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "tv",
     "tags": "television",
     "class": "material-icons",
@@ -24542,6 +27609,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "undo",
     "tags": "arrow",
     "class": "material-icons",
@@ -24550,6 +27618,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "usb",
     "tags": "",
     "class": "material-icons",
@@ -24558,6 +27627,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "verified_user",
     "tags": "checkmark, shield",
     "class": "material-icons",
@@ -24566,6 +27636,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "vertical_align_bottom",
     "tags": "",
     "class": "material-icons",
@@ -24574,6 +27645,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "vertical_align_center",
     "tags": "",
     "class": "material-icons",
@@ -24582,6 +27654,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "vertical_align_top",
     "tags": "",
     "class": "material-icons",
@@ -24590,6 +27663,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "vibration",
     "tags": "",
     "class": "material-icons",
@@ -24598,6 +27672,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "video_library",
     "tags": "",
     "class": "material-icons",
@@ -24606,6 +27681,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "videocam",
     "tags": "record",
     "class": "material-icons",
@@ -24614,6 +27690,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "videocam_off",
     "tags": "",
     "class": "material-icons",
@@ -24622,6 +27699,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "view_agenda",
     "tags": "",
     "class": "material-icons",
@@ -24630,6 +27708,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "view_array",
     "tags": "",
     "class": "material-icons",
@@ -24638,6 +27717,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "view_carousel",
     "tags": "",
     "class": "material-icons",
@@ -24646,6 +27726,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "view_column",
     "tags": "",
     "class": "material-icons",
@@ -24654,6 +27735,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "view_comfy",
     "tags": "",
     "class": "material-icons",
@@ -24662,6 +27744,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "view_compact",
     "tags": "",
     "class": "material-icons",
@@ -24670,6 +27753,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "view_day",
     "tags": "",
     "class": "material-icons",
@@ -24678,6 +27762,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "view_headline",
     "tags": "",
     "class": "material-icons",
@@ -24686,6 +27771,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "view_list",
     "tags": "",
     "class": "material-icons",
@@ -24694,6 +27780,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "view_module",
     "tags": "grid",
     "class": "material-icons",
@@ -24702,6 +27789,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "view_quilt",
     "tags": "",
     "class": "material-icons",
@@ -24710,6 +27798,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "view_stream",
     "tags": "",
     "class": "material-icons",
@@ -24718,6 +27807,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "view_week",
     "tags": "columns",
     "class": "material-icons",
@@ -24726,6 +27816,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "vignette",
     "tags": "",
     "class": "material-icons",
@@ -24734,6 +27825,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "visibility",
     "tags": "eye, show, view",
     "class": "material-icons",
@@ -24742,6 +27834,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "visibility_off",
     "tags": "eye, hide",
     "class": "material-icons",
@@ -24750,6 +27843,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "voice_chat",
     "tags": "camera, chat, speech bubble, video",
     "class": "material-icons",
@@ -24758,6 +27852,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "voicemail",
     "tags": "record",
     "class": "material-icons",
@@ -24766,6 +27861,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "volume_down",
     "tags": "",
     "class": "material-icons",
@@ -24774,6 +27870,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "volume_mute",
     "tags": "",
     "class": "material-icons",
@@ -24782,6 +27879,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "volume_off",
     "tags": "",
     "class": "material-icons",
@@ -24790,6 +27888,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "volume_up",
     "tags": "",
     "class": "material-icons",
@@ -24798,6 +27897,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "vpn_key",
     "tags": "key, lock",
     "class": "material-icons",
@@ -24806,6 +27906,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "vpn_lock",
     "tags": "globe, lock",
     "class": "material-icons",
@@ -24814,6 +27915,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "wallpaper",
     "tags": "picture",
     "class": "material-icons",
@@ -24822,6 +27924,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "warning",
     "tags": "alert, danger",
     "class": "material-icons",
@@ -24830,6 +27933,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "watch",
     "tags": "",
     "class": "material-icons",
@@ -24838,6 +27942,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "wb_auto",
     "tags": "",
     "class": "material-icons",
@@ -24846,6 +27951,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "wb_cloudy",
     "tags": "",
     "class": "material-icons",
@@ -24854,6 +27960,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "wb_incandescent",
     "tags": "lightbulb",
     "class": "material-icons",
@@ -24862,6 +27969,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "wb_iridescent",
     "tags": "",
     "class": "material-icons",
@@ -24870,6 +27978,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "wb_sunny",
     "tags": "",
     "class": "material-icons",
@@ -24878,6 +27987,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "wc",
     "tags": "bathroom, restroom",
     "class": "material-icons",
@@ -24886,6 +27996,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "web",
     "tags": "",
     "class": "material-icons",
@@ -24894,6 +28005,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "whatshot",
     "tags": "fire, flame",
     "class": "material-icons",
@@ -24902,6 +28014,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "widgets",
     "tags": "",
     "class": "material-icons",
@@ -24910,6 +28023,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "wifi",
     "tags": "signal",
     "class": "material-icons",
@@ -24918,6 +28032,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "wifi_lock",
     "tags": "",
     "class": "material-icons",
@@ -24926,6 +28041,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "wifi_tethering",
     "tags": "",
     "class": "material-icons",
@@ -24934,6 +28050,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "work",
     "tags": "briefcase, suitcase",
     "class": "material-icons",
@@ -24942,6 +28059,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "wrap_text",
     "tags": "",
     "class": "material-icons",
@@ -24950,6 +28068,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "youtube_searched_for",
     "tags": "find, magnifying glass",
     "class": "material-icons",
@@ -24958,6 +28077,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "zoom_in",
     "tags": "magnifying glass",
     "class": "material-icons",
@@ -24966,6 +28086,7 @@
   },
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "zoom_out",
     "tags": "magnifying glass",
     "class": "material-icons",
@@ -24975,6 +28096,7 @@
 
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "alert",
     "tags": "warning, triangle, exclamation point",
     "class": "mega-octicon octicon-alert",
@@ -24983,6 +28105,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "arrow-down",
     "tags": "point, direction",
     "class": "mega-octicon octicon-arrow-down",
@@ -24991,6 +28114,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "arrow-left",
     "tags": "point, direction",
     "class": "mega-octicon octicon-arrow-left",
@@ -24999,6 +28123,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "arrow-right",
     "tags": "point, direction",
     "class": "mega-octicon octicon-arrow-right",
@@ -25007,6 +28132,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "arrow-small-down",
     "tags": "point, direction",
     "class": "mega-octicon octicon-arrow-small-down",
@@ -25015,6 +28141,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "arrow-small-left",
     "tags": "point, direction, little, tiny",
     "class": "mega-octicon octicon-arrow-small-left",
@@ -25023,6 +28150,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "arrow-small-right",
     "tags": "point, direction, little, tiny",
     "class": "mega-octicon octicon-arrow-small-right",
@@ -25031,6 +28159,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "arrow-small-up",
     "tags": "point, direction, little, tiny",
     "class": "mega-octicon octicon-arrow-small-up",
@@ -25039,6 +28168,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "arrow-up",
     "tags": "point, direction",
     "class": "mega-octicon octicon-arrow-up",
@@ -25047,6 +28177,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "beaker",
     "tags": "chemistry, flask, science",
     "class": "mega-octicon octicon-beaker",
@@ -25055,6 +28186,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "bell",
     "tags": "audio, sound",
     "class": "mega-octicon octicon-bell",
@@ -25063,6 +28195,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "bold",
     "tags": "text editor",
     "class": "mega-octicon octicon-bold",
@@ -25071,6 +28204,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "book",
     "tags": "book, journal, wiki, readme",
     "class": "mega-octicon octicon-book",
@@ -25079,6 +28213,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "bookmark",
     "tags": "tabbard",
     "class": "mega-octicon octicon-bookmark",
@@ -25087,6 +28222,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "briefcase",
     "tags": "suitcase, business",
     "class": "mega-octicon octicon-briefcase",
@@ -25095,6 +28231,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "broadcast",
     "tags": "rss, radio, signal",
     "class": "mega-octicon octicon-broadcast",
@@ -25103,6 +28240,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "browser",
     "tags": "window, web",
     "class": "mega-octicon octicon-browser",
@@ -25111,6 +28249,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "bug",
     "tags": "insect",
     "class": "mega-octicon octicon-bug",
@@ -25119,6 +28258,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "calendar",
     "tags": "date",
     "class": "mega-octicon octicon-calendar",
@@ -25127,6 +28267,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "check",
     "tags": "checkmark",
     "class": "mega-octicon octicon-check",
@@ -25135,6 +28276,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "checklist",
     "tags": "todo",
     "class": "mega-octicon octicon-checklist",
@@ -25143,6 +28285,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "chevron-down",
     "tags": "angle, arrow",
     "class": "mega-octicon octicon-chevron-down",
@@ -25151,6 +28294,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "chevron-left",
     "tags": "angle, arrow",
     "class": "mega-octicon octicon-chevron-left",
@@ -25159,6 +28303,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "chevron-right",
     "tags": "angle, arrow",
     "class": "mega-octicon octicon-chevron-right",
@@ -25167,6 +28312,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "chevron-up",
     "tags": "angle, arrow",
     "class": "mega-octicon octicon-chevron-up",
@@ -25175,6 +28321,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "circle-slash",
     "tags": "ban, prohibited",
     "class": "mega-octicon octicon-circle-slash",
@@ -25183,6 +28330,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "circuit-board",
     "tags": "developer, hardware, electricity",
     "class": "mega-octicon octicon-circuit-board",
@@ -25191,6 +28339,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "clippy",
     "tags": "clipboard, copy, paste, save",
     "class": "mega-octicon octicon-clippy",
@@ -25199,6 +28348,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "clock",
     "tags": "time, hour, minute, second",
     "class": "mega-octicon octicon-clock",
@@ -25207,6 +28357,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "cloud-download",
     "tags": "save, install, get",
     "class": "mega-octicon octicon-cloud-download",
@@ -25215,6 +28366,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "cloud-upload",
     "tags": "put, export",
     "class": "mega-octicon octicon-cloud-upload",
@@ -25223,6 +28375,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "code",
     "tags": "brackets",
     "class": "mega-octicon octicon-code",
@@ -25231,6 +28384,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "color-mode",
     "tags": "black, white, switch, toggle",
     "class": "mega-octicon octicon-color-mode",
@@ -25239,6 +28393,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "comment",
     "tags": "chat, speech bubble",
     "class": "mega-octicon octicon-comment",
@@ -25247,6 +28402,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "comment-discussion",
     "tags": "chat, speech bubbles",
     "class": "mega-octicon octicon-comment-discussion",
@@ -25255,6 +28411,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "credit-card",
     "tags": "money, billing, payments",
     "class": "mega-octicon octicon-credit-card",
@@ -25263,6 +28420,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "dash",
     "tags": "hyphen, range",
     "class": "mega-octicon octicon-dash",
@@ -25271,6 +28429,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "dashboard",
     "tags": "speed, tachometer",
     "class": "mega-octicon octicon-dashboard",
@@ -25279,6 +28438,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "database",
     "tags": "disks, data",
     "class": "mega-octicon octicon-database",
@@ -25287,6 +28447,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "desktop-download",
     "tags": "",
     "class": "mega-octicon octicon-desktop-download",
@@ -25295,6 +28456,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "device-camera",
     "tags": "photo, picture, image, snapshot",
     "class": "mega-octicon octicon-device-camera",
@@ -25303,6 +28465,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "device-camera-video",
     "tags": "watch, view, media, stream",
     "class": "mega-octicon octicon-device-camera-video",
@@ -25311,6 +28474,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "device-desktop",
     "tags": "computer, display, monitor",
     "class": "mega-octicon octicon-device-desktop",
@@ -25319,6 +28483,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "device-mobile",
     "tags": "phone, iphone, cellphone",
     "class": "mega-octicon octicon-device-mobile",
@@ -25327,6 +28492,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "diff",
     "tags": "difference, changes, compare",
     "class": "mega-octicon octicon-diff",
@@ -25335,6 +28501,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "diff-added",
     "tags": "new, addition",
     "class": "mega-octicon octicon-diff-added",
@@ -25343,6 +28510,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "diff-ignored",
     "tags": "slash",
     "class": "mega-octicon octicon-diff-ignored",
@@ -25351,6 +28519,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "diff-modified",
     "tags": "dot, changed, updated",
     "class": "mega-octicon octicon-diff-modified",
@@ -25359,6 +28528,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "diff-removed",
     "tags": "deleted, subtracted, dash",
     "class": "mega-octicon octicon-diff-removed",
@@ -25367,6 +28537,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "diff-renamed",
     "tags": "moved, arrow",
     "class": "mega-octicon octicon-diff-renamed",
@@ -25375,6 +28546,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "ellipsis",
     "tags": "read, more, hidden, expand",
     "class": "mega-octicon octicon-ellipsis",
@@ -25383,6 +28555,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "eye",
     "tags": "eyeball, see, view",
     "class": "mega-octicon octicon-eye",
@@ -25391,6 +28564,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "file-binary",
     "tags": "bits, document",
     "class": "mega-octicon octicon-file-binary",
@@ -25399,6 +28573,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "file-code",
     "tags": "document, source code",
     "class": "mega-octicon octicon-file-code",
@@ -25407,6 +28582,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "file-directory",
     "tags": "folder",
     "class": "mega-octicon octicon-file-directory",
@@ -25415,6 +28591,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "file-media",
     "tags": "document, image, video, audio",
     "class": "mega-octicon octicon-file-media",
@@ -25423,6 +28600,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "file-pdf",
     "tags": "document",
     "class": "mega-octicon octicon-file-pdf",
@@ -25431,6 +28609,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "file-submodule",
     "tags": "folders",
     "class": "mega-octicon octicon-file-submodule",
@@ -25439,6 +28618,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "file-symlink-directory",
     "tags": "folder, subfolder, link, alias",
     "class": "mega-octicon octicon-file-symlink-directory",
@@ -25447,6 +28627,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "file-symlink-file",
     "tags": "link, alias",
     "class": "mega-octicon octicon-file-symlink-file",
@@ -25455,6 +28636,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "file-text",
     "tags": "document",
     "class": "mega-octicon octicon-file-text",
@@ -25463,6 +28645,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "file-zip",
     "tags": "compress, archive",
     "class": "mega-octicon octicon-file-zip",
@@ -25471,6 +28654,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "flame",
     "tags": "fire, hot, burn, trending",
     "class": "mega-octicon octicon-flame",
@@ -25479,6 +28663,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "fold",
     "tags": "unfold, hide, collapse",
     "class": "mega-octicon octicon-fold",
@@ -25487,6 +28672,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "gear",
     "tags": "cog, settings",
     "class": "mega-octicon octicon-gear",
@@ -25495,6 +28681,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "gift",
     "tags": "present",
     "class": "mega-octicon octicon-gift",
@@ -25503,6 +28690,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "gist",
     "tags": "document, source code",
     "class": "mega-octicon octicon-gist",
@@ -25511,6 +28699,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "gist-secret",
     "tags": "incognito, spy",
     "class": "mega-octicon octicon-gist-secret",
@@ -25519,6 +28708,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "git-branch",
     "tags": "",
     "class": "mega-octicon octicon-git-branch",
@@ -25527,6 +28717,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "git-commit",
     "tags": "save",
     "class": "mega-octicon octicon-git-commit",
@@ -25535,6 +28726,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "git-compare",
     "tags": "difference, changes",
     "class": "mega-octicon octicon-git-compare",
@@ -25543,6 +28735,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "git-merge",
     "tags": "join",
     "class": "mega-octicon octicon-git-merge",
@@ -25551,6 +28744,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "git-pull-request",
     "tags": "review",
     "class": "mega-octicon octicon-git-pull-request",
@@ -25559,6 +28753,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "globe",
     "tags": "earth, planet, world",
     "class": "mega-octicon octicon-globe",
@@ -25567,6 +28762,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "graph",
     "tags": "chart",
     "class": "mega-octicon octicon-graph",
@@ -25575,6 +28771,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "heart",
     "tags": "favorite, like, love",
     "class": "mega-octicon octicon-heart",
@@ -25583,6 +28780,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "history",
     "tags": "clock, time, past, revert",
     "class": "mega-octicon octicon-history",
@@ -25591,6 +28789,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "home",
     "tags": "house, building",
     "class": "mega-octicon octicon-home",
@@ -25599,6 +28798,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "horizontal-rule",
     "tags": "hr",
     "class": "mega-octicon octicon-horizontal-rule",
@@ -25607,6 +28807,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "hubot",
     "tags": "robot",
     "class": "mega-octicon octicon-hubot",
@@ -25615,6 +28816,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "inbox",
     "tags": "email",
     "class": "mega-octicon octicon-inbox",
@@ -25623,6 +28825,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "info",
     "tags": "",
     "class": "mega-octicon octicon-info",
@@ -25631,6 +28834,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "issue-closed",
     "tags": "done, complete",
     "class": "mega-octicon octicon-issue-closed",
@@ -25639,6 +28843,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "issue-opened",
     "tags": "new",
     "class": "mega-octicon octicon-issue-opened",
@@ -25647,6 +28852,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "issue-reopened",
     "tags": "regression",
     "class": "mega-octicon octicon-issue-reopened",
@@ -25655,6 +28861,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "italic",
     "tags": "text editor",
     "class": "mega-octicon octicon-italic",
@@ -25663,6 +28870,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "jersey",
     "tags": "basketball, shirt, sport, uniform",
     "class": "mega-octicon octicon-jersey",
@@ -25671,6 +28879,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "key",
     "tags": "lock, security",
     "class": "mega-octicon octicon-key",
@@ -25679,6 +28888,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "keyboard",
     "tags": "",
     "class": "mega-octicon octicon-keyboard",
@@ -25687,6 +28897,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "law",
     "tags": "balance, scale",
     "class": "mega-octicon octicon-law",
@@ -25695,6 +28906,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "light-bulb",
     "tags": "",
     "class": "mega-octicon octicon-light-bulb",
@@ -25703,6 +28915,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "link",
     "tags": "chain",
     "class": "mega-octicon octicon-link",
@@ -25711,6 +28924,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "link-external",
     "tags": "arrow",
     "class": "mega-octicon octicon-link-external",
@@ -25719,6 +28933,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "list-ordered",
     "tags": "numbered",
     "class": "mega-octicon octicon-list-ordered",
@@ -25727,6 +28942,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "list-unordered",
     "tags": "bullet point",
     "class": "mega-octicon octicon-list-unordered",
@@ -25735,6 +28951,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "location",
     "tags": "map marker",
     "class": "mega-octicon octicon-location",
@@ -25743,6 +28960,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "lock",
     "tags": "security",
     "class": "mega-octicon octicon-lock",
@@ -25751,6 +28969,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "logo-gist",
     "tags": "brand",
     "class": "mega-octicon octicon-logo-gist",
@@ -25759,6 +28978,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "logo-github",
     "tags": "brand",
     "class": "mega-octicon octicon-logo-github",
@@ -25767,6 +28987,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "mail",
     "tags": "email, envelope",
     "class": "mega-octicon octicon-mail",
@@ -25775,6 +28996,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "mail-read",
     "tags": "email, envelope, letter",
     "class": "mega-octicon octicon-mail-read",
@@ -25783,6 +29005,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "mail-reply",
     "tags": "email",
     "class": "mega-octicon octicon-mail-reply",
@@ -25791,6 +29014,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "mark-github",
     "tags": "octocat",
     "class": "mega-octicon octicon-mark-github",
@@ -25799,6 +29023,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "markdown",
     "tags": "logo",
     "class": "mega-octicon octicon-markdown",
@@ -25807,6 +29032,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "megaphone",
     "tags": "bullhorn, loud, shout, broadcast",
     "class": "mega-octicon octicon-megaphone",
@@ -25815,6 +29041,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "mention",
     "tags": "at",
     "class": "mega-octicon octicon-mention",
@@ -25823,6 +29050,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "milestone",
     "tags": "marker, sign",
     "class": "mega-octicon octicon-milestone",
@@ -25831,6 +29059,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "mirror",
     "tags": "reflect",
     "class": "mega-octicon octicon-mirror",
@@ -25839,6 +29068,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "mortar-board",
     "tags": "education, graduation cap, hat",
     "class": "mega-octicon octicon-mortar-board",
@@ -25847,6 +29077,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "mute",
     "tags": "audio, sound, volume",
     "class": "mega-octicon octicon-mute",
@@ -25855,6 +29086,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "no-newline",
     "tags": "return",
     "class": "mega-octicon octicon-no-newline",
@@ -25863,6 +29095,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "octoface",
     "tags": "octocat",
     "class": "mega-octicon octicon-octoface",
@@ -25871,6 +29104,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "organization",
     "tags": "people, group, team",
     "class": "mega-octicon octicon-organization",
@@ -25879,6 +29113,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "package",
     "tags": "box, shipment",
     "class": "mega-octicon octicon-package",
@@ -25887,6 +29122,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "paintcan",
     "tags": "art, bucket",
     "class": "mega-octicon octicon-paintcan",
@@ -25895,6 +29131,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "pencil",
     "tags": "edit, write",
     "class": "mega-octicon octicon-pencil",
@@ -25903,6 +29140,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "person",
     "tags": "human",
     "class": "mega-octicon octicon-person",
@@ -25911,6 +29149,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "pin",
     "tags": "pushpin, thumbtack",
     "class": "mega-octicon octicon-pin",
@@ -25919,6 +29158,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "plug",
     "tags": "power",
     "class": "mega-octicon octicon-plug",
@@ -25927,6 +29167,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "plus",
     "tags": "add, new",
     "class": "mega-octicon octicon-plus",
@@ -25935,6 +29176,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "primitive-dot",
     "tags": "circle",
     "class": "mega-octicon octicon-primitive-dot",
@@ -25943,6 +29185,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "primitive-square",
     "tags": "",
     "class": "mega-octicon octicon-primitive-square",
@@ -25951,6 +29194,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "pulse",
     "tags": "graph, trend line, signal",
     "class": "mega-octicon octicon-pulse",
@@ -25959,6 +29203,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "question",
     "tags": "help, question mark",
     "class": "mega-octicon octicon-question",
@@ -25967,6 +29212,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "quote",
     "tags": "quotation mark",
     "class": "mega-octicon octicon-quote",
@@ -25975,6 +29221,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "radio-tower",
     "tags": "broadcast",
     "class": "mega-octicon octicon-radio-tower",
@@ -25983,6 +29230,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "repo",
     "tags": "book, git, journal",
     "class": "mega-octicon octicon-repo",
@@ -25991,6 +29239,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "repo-clone",
     "tags": "book, git, journal",
     "class": "mega-octicon octicon-repo-clone",
@@ -25999,6 +29248,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "repo-force-push",
     "tags": "book, git, journal",
     "class": "mega-octicon octicon-repo-force-push",
@@ -26007,6 +29257,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "repo-forked",
     "tags": "book, git, journal",
     "class": "mega-octicon octicon-repo-forked",
@@ -26015,6 +29266,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "repo-pull",
     "tags": "book, git, journal",
     "class": "mega-octicon octicon-repo-pull",
@@ -26023,6 +29275,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "repo-push",
     "tags": "book, git, journal",
     "class": "mega-octicon octicon-repo-push",
@@ -26031,6 +29284,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "rocket",
     "tags": "spaceship",
     "class": "mega-octicon octicon-rocket",
@@ -26039,6 +29293,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "rss",
     "tags": "broadcast, feed",
     "class": "mega-octicon octicon-rss",
@@ -26047,6 +29302,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "ruby",
     "tags": "diamond, gem",
     "class": "mega-octicon octicon-ruby",
@@ -26055,6 +29311,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "search",
     "tags": "find, magnifying glass",
     "class": "mega-octicon octicon-search",
@@ -26063,6 +29320,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "server",
     "tags": "computers",
     "class": "mega-octicon octicon-server",
@@ -26071,6 +29329,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "settings",
     "tags": "equalizer, sliders",
     "class": "mega-octicon octicon-settings",
@@ -26079,6 +29338,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "shield",
     "tags": "lock, security",
     "class": "mega-octicon octicon-shield",
@@ -26087,6 +29347,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "sign-in",
     "tags": "door, enter, login",
     "class": "mega-octicon octicon-sign-in",
@@ -26095,6 +29356,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "sign-out",
     "tags": "door, exit, logout",
     "class": "mega-octicon octicon-sign-out",
@@ -26103,6 +29365,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "squirrel",
     "tags": "animal",
     "class": "mega-octicon octicon-squirrel",
@@ -26111,6 +29374,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "star",
     "tags": "like, rating",
     "class": "mega-octicon octicon-star",
@@ -26119,6 +29383,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "stop",
     "tags": "caution, danger, exclamation point, warning",
     "class": "mega-octicon octicon-stop",
@@ -26127,6 +29392,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "sync",
     "tags": "cycle, refresh, reload, loop",
     "class": "mega-octicon octicon-sync",
@@ -26135,6 +29401,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "tag",
     "tags": "release",
     "class": "mega-octicon octicon-tag",
@@ -26143,6 +29410,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "tasklist",
     "tags": "",
     "class": "mega-octicon octicon-tasklist",
@@ -26151,6 +29419,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "telescope",
     "tags": "science, view, explore",
     "class": "mega-octicon octicon-telescope",
@@ -26159,6 +29428,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "terminal",
     "tags": "console, shell",
     "class": "mega-octicon octicon-terminal",
@@ -26167,6 +29437,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "text-size",
     "tags": "font",
     "class": "mega-octicon octicon-text-size",
@@ -26175,6 +29446,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "three-bars",
     "tags": "hamburger menu, more",
     "class": "mega-octicon octicon-three-bars",
@@ -26183,6 +29455,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "thumbsdown",
     "tags": "dislike, rating",
     "class": "mega-octicon octicon-thumbsdown",
@@ -26191,6 +29464,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "thumbsup",
     "tags": "like, rating",
     "class": "mega-octicon octicon-thumbsup",
@@ -26199,6 +29473,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "tools",
     "tags": "screwdriver, wrench, settings",
     "class": "mega-octicon octicon-tools",
@@ -26207,6 +29482,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "trashcan",
     "tags": "garbage, rubbish, delete",
     "class": "mega-octicon octicon-trashcan",
@@ -26215,6 +29491,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "triangle-down",
     "tags": "arrow, direction",
     "class": "mega-octicon octicon-triangle-down",
@@ -26223,6 +29500,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "triangle-left",
     "tags": "arrow, direction",
     "class": "mega-octicon octicon-triangle-left",
@@ -26231,6 +29509,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "triangle-right",
     "tags": "arrow, direction",
     "class": "mega-octicon octicon-triangle-right",
@@ -26239,6 +29518,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "triangle-up",
     "tags": "arrow, direction",
     "class": "mega-octicon octicon-triangle-up",
@@ -26247,6 +29527,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "unfold",
     "tags": "expand, open, reveal",
     "class": "mega-octicon octicon-unfold",
@@ -26255,6 +29536,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "unmute",
     "tags": "audio, sound, volume",
     "class": "mega-octicon octicon-unmute",
@@ -26263,6 +29545,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "versions",
     "tags": "history",
     "class": "mega-octicon octicon-versions",
@@ -26271,6 +29554,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "watch",
     "tags": "",
     "class": "mega-octicon octicon-watch",
@@ -26279,6 +29563,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "x",
     "tags": "remove, close, delete",
     "class": "mega-octicon octicon-x",
@@ -26287,6 +29572,7 @@
   },
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "zap",
     "tags": "electricity, lightning bolt",
     "class": "mega-octicon octicon-zap",

--- a/index.html
+++ b/index.html
@@ -49,6 +49,7 @@
           <span class="btn" data-copy="class">Class</span>
           <span class="btn" data-copy="name">Name</span>
           <span class="btn" data-copy="unicode">Unicode</span>
+          <span class="btn" data-copy="svg">SVG Markup</span>
         </div>
       </div>
       <hr>
@@ -152,6 +153,7 @@
     <script src="js/vendor/algoliasearch.min.js"></script>
     <script src="bower_components/purl/purl.js"></script>
     <script src="bower_components/zeroclipboard/dist/ZeroClipboard.min.js"></script>
+    <script src="js/lib/SVGFont.js"></script>
     <script src="js/script.js"></script>
     <script>
       (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){

--- a/js/lib/SVGFont.js
+++ b/js/lib/SVGFont.js
@@ -1,0 +1,223 @@
+'use strict';
+
+// Source (ES6): https://github.com/grimen/svg-fontglyphs2svg/blob/master/src/js/svgfont.js
+
+var _createClass = (function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; })();
+
+if (typeof exports !== 'undefined') {
+    Object.defineProperty(exports, "__esModule", {
+        value: true
+    });
+}
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+var SVGFont = (function () {
+    function SVGFont(id, uri, options) {
+        var _this = this;
+
+        _classCallCheck(this, SVGFont);
+
+        this.id = id;
+        this.uri = uri;
+        this.options = options || {};
+        this.verbose = true;
+
+        this.listeners = [];
+        this.onload = function () {
+            if (_this.verbose) console.log('[SVGFont]: LOAD', [_this.id, _this.uri]);
+        };
+        this.onerror = function () {
+            if (_this.verbose) console.error('[SVGFont]: ERROR', [_this.id, _this.uri]);
+        };
+
+        this.embed();
+    }
+
+    _createClass(SVGFont, [{
+        key: 'on',
+        value: function on(name, callback) {
+            if (this.complete) {
+                callback();
+            }
+            this.listeners.push([name, callback]);
+        }
+    }, {
+        key: 'embed',
+        value: function embed() {
+            var _this2 = this;
+
+            if (!this.object) {
+                (function () {
+                    var _object = document.createElement('object');
+                    _object.setAttribute('id', _this2.id);
+                    _object.setAttribute('type', 'image/svg+xml');
+                    _object.setAttribute('data', _this2.uri);
+
+                    var _onLoad = function _onLoad() {
+                        var _content = _object.contentDocument.querySelector('svg');
+
+                        if (!_content) {
+                            return _onError();
+                        }
+
+                        _this2.complete = true;
+
+                        _object.setAttribute('data-complete', _this2.complete);
+
+                        _this2.onload();
+
+                        _this2.listeners.forEach(function (listener) {
+                            var name = listener[0],
+                                callback = listener[1];
+                            if (name === 'load') callback();
+                        });
+                    };
+
+                    var _onError = function _onError() {
+                        _this2.complete = false;
+
+                        _object.setAttribute('data-complete', _this2.complete);
+
+                        _this2.onerror();
+
+                        _this2.listeners.forEach(function (listener) {
+                            var name = listener[0],
+                                callback = listener[1];
+                            if (name === 'error') callback();
+                        });
+                    };
+
+                    _object.addEventListener('load', _onLoad, false);
+                    _object.addEventListener('error', _onError, false);
+
+                    document.body.appendChild(_object);
+                })();
+            }
+        }
+    }, {
+        key: 'paths',
+        value: function paths(options) {
+            var _this3 = this;
+
+            return this.glyphs.map(function (g) {
+                return _this3.fontfaceGlyphToPath(g, options);
+            }).filter(function (v) {
+                return !!v;
+            });
+        }
+    }, {
+        key: 'pathByUnicode',
+        value: function pathByUnicode(value, options) {
+            var _this4 = this;
+
+            options = options || {};
+
+            return this.glyphs.filter(function (g) {
+                var unicode = g.getAttribute('unicode');
+
+                // DEBUG:
+                // console.log(unicode, escape(unicode), value, `${value}$`, (new RegExp(`${value}$`, 'gmi').test(escape(unicode))))
+
+                return new RegExp(value + '$', 'gmi').test(escape(unicode));
+            }).map(function (g) {
+                return _this4.fontfaceGlyphToPath(g, options);
+            })[0];
+        }
+    }, {
+        key: 'fontfaceGlyphToPath',
+        value: function fontfaceGlyphToPath(glyph, options) {
+            options = options || {};
+            options.width = options.width || this.defaults.width;
+            options.height = options.height || this.defaults.height;
+
+            var _fontface = this.fontfaceProps;
+
+            if (!glyph) return null;
+
+            var _d = glyph.getAttribute('d');
+            var _unicode = glyph.getAttribute('unicode');
+            var _unicodeHex = escape(_unicode).toLowerCase().replace('%u', '');
+            var _unicodeHTMLEntity = escape(_unicode).toLowerCase().replace('%u', '&#x') + ';';
+
+            if (!_d) return null;
+            if (_d === ' M0,0') return null;
+            if (_d === 'M0 0 L0 0 Z') return null;
+
+            var ns = 'http://www.w3.org/2000/svg';
+
+            var _svg = document.createElementNS(ns, 'svg');
+            // _svg.setAttribute('data-unicode', _unicode)
+            _svg.setAttribute('data-unicode-hex', _unicodeHex);
+            // _svg.setAttribute('data-unicode-htmlentity', _unicodeHTMLEntity)
+            _svg.setAttribute('xmlns', ns);
+            _svg.setAttribute('version', '1.1');
+            _svg.setAttribute('width', options.width) / _svg.setAttribute('height', options.height);
+            _svg.setAttribute('viewBox', '0 0 ' + _fontface.unitsPerEm + ' ' + _fontface.unitsPerEm);
+
+            var _path = document.createElementNS(ns, 'path');
+            _path.setAttribute('transform', 'scale(1, -1) translate(0, -' + _fontface.ascent + ')');
+            _path.setAttribute('d', _d);
+            _path.setAttribute('fill', 'black');
+            _path.setAttribute('stroke', 'none');
+
+            _svg.appendChild(_path);
+
+            return _svg;
+        }
+    }, {
+        key: 'defaults',
+        get: function get() {
+            return {
+                width: 16,
+                height: 16
+            };
+        }
+    }, {
+        key: 'object',
+        get: function get() {
+            var _object = document.querySelector('object[id="' + this.id + '"]');
+            return _object;
+        }
+    }, {
+        key: 'svg',
+        get: function get() {
+            if (!this.object) return null;
+
+            var _svg = this.object.contentDocument.querySelector('svg');
+
+            return _svg;
+        }
+    }, {
+        key: 'fontface',
+        get: function get() {
+            if (!this.svg) return null;
+            return this.svg.querySelector('font-face');
+        }
+    }, {
+        key: 'fontfaceProps',
+        get: function get() {
+            if (!this.fontface) return null;
+
+            var _props = {
+                unitsPerEm: this.fontface.getAttribute('units-per-em'),
+                ascent: this.fontface.getAttribute('ascent'),
+                descent: this.fontface.getAttribute('descent')
+            };
+
+            return _props;
+        }
+    }, {
+        key: 'glyphs',
+        get: function get() {
+            var glyphs = this.svg.querySelectorAll('glyph');
+            return Array.prototype.slice.call(glyphs);
+        }
+    }]);
+
+    return SVGFont;
+})();
+
+if (typeof exports !== 'undefined') {
+    exports.default = SVGFont;
+}

--- a/js/script.js
+++ b/js/script.js
@@ -1,12 +1,12 @@
 (function() {
   var iconsIndex = new AlgoliaSearch("9JQV0RIHU0", "2219d421236cba4cf37a98e7f97b3ec5").initIndex('icons'),
-    innerTemplate = '<div class="entry col-lg-1 col-md-2 col-sm-3 col-xs-3" data-name={{{name}}} data-unicode="{{{unicode}}}">' +
+    innerTemplate = '<div class="entry col-lg-1 col-md-2 col-sm-3 col-xs-3" data-library="{{{library}}}" data-name="{{{name}}}" data-unicode="{{{unicode}}}">' +
       '<div class="description">{{{class}}}</div>' +
       '<div class="thumb">{{{html}}}</div>' +
       '<div class="name">{{{_highlightResult.name.value}}}</div>' +
       '<div class="tags hidden-xs">{{{_highlightResult.tags.value}}}</div>' +
       '</div>',
-    allTemplate = '<div class="entry col-lg-1 col-md-2 col-sm-3 col-xs-3" data-name={{{name}}} data-unicode="{{{unicode}}}">' +
+    allTemplate = '<div class="entry col-lg-1 col-md-2 col-sm-3 col-xs-3" data-library="{{{library}}}" data-name="{{{name}}}" data-unicode="{{{unicode}}}">' +
       '<div class="description">{{{class}}}</div>' +
       '<div class="thumb">{{{html}}}</i></div>' +
       '<div class="name">{{{name}}}</div>' +
@@ -244,22 +244,35 @@
   }
 
   function copyText(target) {
-    var text;
+    var text, object;
+    var library = target.attr("data-library");
 
     if (state.copy === "markup") {
+      // "Name": `f35f` => `<i class="ionicons ion-android-arrow-dropdown"></i>`
       text = target.find(".thumb").html();
     } else if (state.copy === "class") {
+      // "Name": `f35f` => `ionicons ion-android-arrow-dropdown`
       text = target.find(".description").html();
     } else if (state.copy === "name") {
+      // "Name": `f35f` => `android-arrow-dropdown`
       text = target.attr("data-name");
     } else if (state.copy === "unicode") {
+      // "Unicode": `f12a` => <UnicodeChar>
       if (target.find("i").hasClass("material-icons")) {
         text = target.attr("data-unicode");
       } else {
         var hex = target.attr("data-unicode");
         text = String.fromCharCode(parseInt(hex, 16));
       }
+    } else if (state.copy === "svg") {
+      // "SVG Markup": `f12a` => `<svg ...><path ... d="..."></path></svg>`
+      var unicodeHex = target.attr("data-unicode")
+      var svgFont = svgFonts.filter(function(f) { return f.id === library })[0]
+      object = svgFont.pathByUnicode(unicodeHex, {width: 24, height: 24})
+      text = object.outerHTML
     }
+
+    console.log("[" + library + "]: COPY `" + state.copy + "`\n---\n", text, "\n---\n", object, "\n\n")
 
     return text;
   }
@@ -286,4 +299,20 @@
       }, delay);
     };
   }
+
+  var svgFontRoot = '/bower_components'
+  var svgFonts = []
+
+  setTimeout(function() {
+    svgFonts = [
+      new SVGFont('font-awesome', svgFontRoot + '/font-awesome/fonts/fontawesome-webfont.svg'),
+      new SVGFont('foundation', svgFontRoot + '/foundation-icon-fonts/foundation-icons.svg'),
+      new SVGFont('glyphicons', svgFontRoot + '/bootstrap/dist/fonts/glyphicons-halflings-regular.svg'),
+      new SVGFont('icomoon', svgFontRoot + '/icomoon/dist/fonts/icomoon.svg'),
+      new SVGFont('ionicons', svgFontRoot + '/ionicons/fonts/ionicons.svg'),
+      new SVGFont('material', svgFontRoot + '/material-design-icons/iconfont/MaterialIcons-Regular.svg'),
+      new SVGFont('octicons', svgFontRoot + '/octicons/octicons/octicons.svg'),
+    ]
+  }, 0)
+
 }());

--- a/templates/batch.handlebars
+++ b/templates/batch.handlebars
@@ -2,6 +2,7 @@
   {{#each font-awesome}}
   {
     "_tags": ["font-awesome"],
+    "library": "font-awesome",
     "name": "{{name}}",
     "tags": "{{tags}}",
     "class": "fa fa-{{name}}",
@@ -13,6 +14,7 @@
   {{#each foundation}}
   {
     "_tags": ["foundation"],
+    "library": "foundation",
     "name": "{{name}}",
     "tags": "{{tags}}",
     "class": "fi-{{name}}",
@@ -24,6 +26,7 @@
   {{#each glyphicons}}
   {
     "_tags": ["glyphicons"],
+    "library": "glyphicons",
     "name": "{{name}}",
     "tags": "{{tags}}",
     "class": "glyphicon glyphicon-{{name}}",
@@ -35,6 +38,7 @@
   {{#each ionicons}}
   {
     "_tags": ["ionicons"],
+    "library": "ionicons",
     "name": "{{name}}",
     "tags": "{{tags}}",
     "class": "ionicons ion-{{name}}",
@@ -46,6 +50,7 @@
   {{#each icomoon}}
   {
     "_tags": ["icomoon"],
+    "library": "icomoon",
     "name": "{{name}}",
     "tags": "{{tags}}",
     "class": "icomoon icon-{{name}}",
@@ -57,6 +62,7 @@
   {{#each material}}
   {
     "_tags": ["material"],
+    "library": "material",
     "name": "{{name}}",
     "tags": "{{tags}}",
     "class": "material-icons",
@@ -68,6 +74,7 @@
   {{#each octicons}}
   {
     "_tags": ["octicons"],
+    "library": "octicons",
     "name": "{{name}}",
     "tags": "{{tags}}",
     "class": "mega-octicon octicon-{{name}}",


### PR DESCRIPTION
Quickly queried and transpiled from embedded *.svg fonts. A generic
approach that works with any icon fonts without extra work. Additional
requirement: Adds `library` to each icon instance, makes sense for
other reasons too.